### PR TITLE
itk package: Skip install of deprecated modules and .mdx files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ if(ITKPythonPackage_SUPERBUILD)
   #-----------------------------------------------------------------------------
   include(ExternalProject)
 
-  set(ITK_REPOSITORY "git://github.com/InsightSoftwareConsortium/ITK.git")
-  set(ITK_GIT_TAG "origin/master")
+  set(ITK_REPOSITORY "git://github.com/jcfr/ITK.git")
+  set(ITK_GIT_TAG "origin/add-itk-wrap-python-legacy-option-and-skip-mdx-install")
 
   # Add an empty external project
   function(itk_ExternalProject_Add_Empty proj depends)
@@ -151,6 +151,7 @@ if(ITKPythonPackage_SUPERBUILD)
       -DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel
       -DITK_LEGACY_SILENT:BOOL=ON
       -DITK_WRAP_PYTHON:BOOL=ON
+      -DITK_WRAP_PYTHON_LEGACY:BOOL=OFF
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
       -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}


### PR DESCRIPTION
Details of ITK changes:

commit jcfr/ITK@afaa7f1
Author: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
Date:   Thu Feb 2 23:50:11 2017 -0500

    BUG: ITKPython: Do not install *.mdx files required only at generation time

    Change-Id: I9f28fb746747cd21dce160fbb6450d8cdc2be47d

commit jcfr/ITK@932ea7e
Author: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
Date:   Thu Feb 2 19:25:10 2017 -0500

    ENH: Introduce ITK_WRAP_PYTHON_LEGACY to exclude older Python package layout

    Change-Id: I2749b1133f43b8c142400b5aef8eb767f0ca8998