### PR TITLE
cmake: Use MinSizeRel CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,22 @@ if(ITKPythonPackage_SUPERBUILD)
   option ( ITKPythonPackage_BUILD_PYTHON "Build ITK python module" ON )
   mark_as_advanced( ITKPythonPackage_BUILD_PYTHON )
 
+  # Set a default build type if none was specified
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'MinSizeRel' as none was specified.")
+    set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "Choose the type of build." FORCE)
+    mark_as_advanced(CMAKE_BUILD_TYPE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug"
+      "Release" "MinSizeRel" "RelWithDebInfo")
+  endif()
+  set(ep_common_cmake_cache_args)
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND ep_common_cmake_cache_args
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
+
   #-----------------------------------------------------------------------------
   # compile with multiple processors
   include(ProcessorCount)
@@ -155,6 +171,7 @@ if(ITKPythonPackage_SUPERBUILD)
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
       -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
+      ${ep_common_cmake_cache_args}
     USES_TERMINAL_DOWNLOAD 1
     USES_TERMINAL_UPDATE 1
     USES_TERMINAL_CONFIGURE 1


### PR DESCRIPTION
For faster builds and smaller packages.