### PR TITLE
Fix specification of CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,22 +21,6 @@ if(ITKPythonPackage_SUPERBUILD)
   option ( ITKPythonPackage_BUILD_PYTHON "Build ITK python module" ON )
   mark_as_advanced( ITKPythonPackage_BUILD_PYTHON )
 
-  # Set a default build type if none was specified
-  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    message(STATUS "Setting build type to 'MinSizeRel' as none was specified.")
-    set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "Choose the type of build." FORCE)
-    mark_as_advanced(CMAKE_BUILD_TYPE)
-    # Set the possible values of build type for cmake-gui
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug"
-      "Release" "MinSizeRel" "RelWithDebInfo")
-  endif()
-  set(ep_common_cmake_cache_args)
-  if(NOT CMAKE_CONFIGURATION_TYPES)
-    list(APPEND ep_common_cmake_cache_args
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      )
-  endif()
-
   #-----------------------------------------------------------------------------
   # compile with multiple processors
   include(ProcessorCount)

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -67,7 +67,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
     echo "PYTHON_LIBRARY:${PYTHON_LIBRARY}"
 
     ${PYBIN}/pip install -r /work/requirements-dev.txt
-    ${PYBIN}/python setup.py bdist_wheel -G Ninja -- \
+    ${PYBIN}/python setup.py bdist_wheel --build-type MinSizeRel -G Ninja -- \
       -DITK_SOURCE_DIR:PATH=/work/standalone-${arch}-build/ITK-source \
       -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE} \
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR} \


### PR DESCRIPTION
We should and have to do this in our scripts, so that a general build has
Release Build type and so skbuild does not clobber / specify the build type to
Release.