### PR TITLE
Propagate CMAKE_BUILD_TYPE to ITK's configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 
 if(ITKPythonPackage_SUPERBUILD)
 
+  set(ep_common_cmake_cache_args)
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND ep_common_cmake_cache_args
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
   #-----------------------------------------------------------------------------
   # Options
 


### PR DESCRIPTION
This is specified by scikit-build.