### PR TITLE
Ensure CMAKE_MAKE_PROGRAM is passed into ExternalProjects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ if(ITKPythonPackage_SUPERBUILD)
       -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES})
   endif()
 
+  if(CMAKE_MAKE_PROGRAM)
+    list(APPEND ep_common_cmake_cache_args
+      -DCMAKE_MAKE_PROGRAM:FILEPATH=${CMAKE_MAKE_PROGRAM})
+  endif()
+
   #-----------------------------------------------------------------------------
   # compile with multiple processors
   include(ProcessorCount)
@@ -200,6 +205,7 @@ if(ITKPythonPackage_SUPERBUILD)
       -DITKPythonPackage_SUPERBUILD:BOOL=0
       -DITK_DIR:PATH=${ITK_DIR}
       -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+      ${ep_common_cmake_cache_args}
     USES_TERMINAL_CONFIGURE 1
     INSTALL_COMMAND ""
     DEPENDS ITK

--- a/scripts/windows-build-wheels.ps1
+++ b/scripts/windows-build-wheels.ps1
@@ -58,6 +58,8 @@ param (
   Write-Host "PYTHON_LIBRARY:${PYTHON_LIBRARY}"
 
   $pip = Join-Path $venvDir "Scripts\\pip.exe"
+  $NINJA_EXECUTABLE = Join-Path $rootDir "venv-27-x64\Scripts\ninja.exe"
+  Write-Host "NINJA_EXECUTABLE:${NINJA_EXECUTABLE}"
 
   # Update PATH
   $old_path = $env:PATH


### PR DESCRIPTION
The full path is required to find ninja.exe when it is not in the path.