### PR TITLE
Strip libraries to decrease package size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ else()
   install(CODE "
 unset(CMAKE_INSTALL_COMPONENT)
 set(COMPONENT \"PythonWheelRuntimeLibraries\")
+set(CMAKE_INSTALL_DO_STRIP 1)
 include\(\"${ITK_DIR}/cmake_install.cmake\")
 unset(CMAKE_INSTALL_COMPONENT)
 ")


### PR DESCRIPTION
CMAKE_INSTALL_DO_STRIP is used in the cmake_install.cmake files to
determine whether to run the 'strip' executable on the C extension
binaries.

This reduces package size by about 15% on Unix-like systems.