### PR TITLE
Install NumPy when testing virtualenv installs

### DIFF
--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -89,6 +89,8 @@ for PYBIN in "${PYBINARIES[@]}"; do
         continue
     fi
     ${PYBIN}/pip install itk --user --no-cache-dir --no-index -f /work/dist
+    ${PYBIN}/pip install --user numpy
     (cd $HOME; ${PYBIN}/python -c 'from itk import ITKCommon;')
+    (cd $HOME; ${PYBIN}/python -c 'import itk; image = itk.Image[itk.UC, 2].New()')
     (cd $HOME; ${PYBIN}/python -c 'import itkConfig; itkConfig.LazyLoading = False; import itk;')
 done

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -95,6 +95,8 @@ $DELOCATE_WHEEL ${SCRIPT_DIR}/../dist/*.whl # copies library dependencies into w
 # Install packages and test
 for VENV in "${VENVS[@]}"; do
     ${VENV}/bin/pip install itk --no-cache-dir --no-index -f ${SCRIPT_DIR}/../dist
+    ${VENV}/bin/pip install numpy
     (cd $HOME; ${VENV}/bin/python -c 'import itk;')
     (cd $HOME; ${VENV}/bin/python -c 'import itk; image = itk.Image[itk.UC, 2].New()')
+    (cd $HOME; ${VENV}/bin/python -c 'import itkConfig; itkConfig.LazyLoading = False; import itk;')
 done


### PR DESCRIPTION
The NumPy bridge is now enabled by default in the build, and loading all
the modules will result in an `import numpy` error otherwise.