### PR TITLE
STYLE: Renaming of manylinux-libpython-not-needed-symbols-exported-by…

### DIFF
--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -43,6 +43,6 @@ echo "Building wheels for $arch"
 # not the extension itself is explicitly linked against libpython. [...]"
 #
 # Source: https://www.python.org/dev/peps/pep-0513/#libpythonx-y-so-1
-PYTHON_LIBRARY=$(cd $(dirname $0); pwd)/manylinux-libpython-not-needed-symbols-exported-by-interpreter
+PYTHON_LIBRARY=$(cd $(dirname $0); pwd)/libpython-not-needed-symbols-exported-by-interpreter
 touch ${PYTHON_LIBRARY}
 

--- a/scripts/macpython-build-common.sh
+++ b/scripts/macpython-build-common.sh
@@ -52,5 +52,5 @@ DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
 # not the extension itself is explicitly linked against libpython. [...]"
 #
 # Source: https://www.python.org/dev/peps/pep-0513/#libpythonx-y-so-1
-PYTHON_LIBRARY=$(cd $(dirname $0); pwd)/internal/manylinux-libpython-not-needed-symbols-exported-by-interpreter
+PYTHON_LIBRARY=$(cd $(dirname $0); pwd)/internal/libpython-not-needed-symbols-exported-by-interpreter
 touch ${PYTHON_LIBRARY}


### PR DESCRIPTION
…-interpreter to libpython-not-needed-symbols-exported-by-interpreter

This file is used for both python and linux