### PR TITLE
macpython: improve tool install logic

### DIFF
--- a/scripts/macpython-build-common.sh
+++ b/scripts/macpython-build-common.sh
@@ -28,17 +28,6 @@ for PYBIN in "${PYBINARIES[@]}"; do
     VENVS+=(${VENV})
 done
 
-VENV="${VENVS[0]}"
-PYTHON_EXECUTABLE=${VENV}/bin/python
-$PYTHON_EXECUTABLE -m pip install --no-cache cmake
-CMAKE_EXECUTABLE=${VENV}/bin/cmake
-$PYTHON_EXECUTABLE -m pip install --no-cache ninja
-NINJA_EXECUTABLE=${VENV}/bin/ninja
-$PYTHON_EXECUTABLE -m pip install --no-cache delocate
-DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
-DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
-
-
 # Since the python interpreter exports its symbol (see [1]), python
 # modules should not link against any python libraries.
 # To ensure it is not the case, we configure the project using an empty

--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -11,6 +11,16 @@
 script_dir="`cd $(dirname $0); pwd`"
 source "${script_dir}/macpython-build-common.sh"
 
+VENV="${VENVS[0]}"
+PYTHON_EXECUTABLE=${VENV}/bin/python
+$PYTHON_EXECUTABLE -m pip install --no-cache cmake
+CMAKE_EXECUTABLE=${VENV}/bin/cmake
+$PYTHON_EXECUTABLE -m pip install --no-cache ninja
+NINJA_EXECUTABLE=${VENV}/bin/ninja
+$PYTHON_EXECUTABLE -m pip install --no-cache delocate
+DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
+DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
+
 # Compile wheels re-using standalone project and archive cache
 for VENV in "${VENVS[@]}"; do
     py_mm=$(basename ${VENV})

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -26,6 +26,16 @@ for PYBIN in "${PYBINARIES[@]}"; do
     VENVS+=(${VENV})
 done
 
+VENV="${VENVS[0]}"
+PYTHON_EXECUTABLE=${VENV}/bin/python
+$PYTHON_EXECUTABLE -m pip install --no-cache cmake
+CMAKE_EXECUTABLE=${VENV}/bin/cmake
+$PYTHON_EXECUTABLE -m pip install --no-cache ninja
+NINJA_EXECUTABLE=${VENV}/bin/ninja
+$PYTHON_EXECUTABLE -m pip install --no-cache delocate
+DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
+DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
+
 # Build standalone project and populate archive cache
 mkdir -p standalone-build
 pushd standalone-build > /dev/null 2>&1


### PR DESCRIPTION
In the itk wheels build, the venv's are not available until after they are
created in the itk build script. VENVS[0] are not necessarily the same between
runs -- ensure the tools are always present in the module wheel build script.