### PR TITLE
mac-module-wheels: use dot progress during download

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -3,7 +3,7 @@
 # This module should be pull and run from an ITKModule root directory to generate the Mac python wheels of this module,
 # it is used by the .travis.yml file contained in ITKModuleTemplate: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate
 
-wget -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/v4.12.0.post1/ITKPythonBuilds-macosx.tar.zst -O ITKPythonBuilds-macosx.tar.zst --retry-connrefused --waitretry=1
+wget --show-progress --progress=dot -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/v4.12.0.post1/ITKPythonBuilds-macosx.tar.zst -O ITKPythonBuilds-macosx.tar.zst --retry-connrefused --waitretry=1
 brew install zstd
 unzstd ITKPythonBuilds-macosx.tar.zst -o ITKPythonBuilds-macosx.tar
 brew install gnu-tar


### PR DESCRIPTION
To prevent timeouts on TravisCI

CC: @jbvimort 