### PR TITLE
ENH: Fixing the windows python wheels automatic generation scripts

### DIFF
--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -1,7 +1,7 @@
 trap { Write-Error $_; Exit 1 }
 
 set-alias sz "$env:ProgramFiles\7-Zip\7z.exe"  
-
+iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/v4.12.0.post1/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
 sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 C:\Python27-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py


### PR DESCRIPTION
Adding of a new line in order to re-install the different version of python (with the good revision) on Appveyor