### PR TITLE
ENH: Add scripts to generate the ITKPythonBuilds-* tarballs

### DIFF
--- a/scripts/dockcross-manylinux-build-tarball.sh
+++ b/scripts/dockcross-manylinux-build-tarball.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script creates a tarball of the ITK Python package build tree. It is
+# downloaded by the external module build scripts and used to build their
+# Python package on GitHub CI services.
+
+cd /home/kitware/Packaging
+tar -c --to-stdout \
+  ITKPythonPackage/ITK-* \
+  ITKPythonPackage/standalone-* \
+  ITKPythonPackage/scripts > ITKPythonBuilds-linux.tar
+/home/kitware/Support/zstd-build/programs/zstd -f \
+  ./ITKPythonBuilds-linux.tar \
+  -o ./ITKPythonBuilds-linux.tar.zst

--- a/scripts/macpython-build-tarball.sh
+++ b/scripts/macpython-build-tarball.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# This script creates a tarball of the ITK Python package build tree. It is
+# downloaded by the external module build scripts and used to build their
+# Python package on GitHub CI services.
+
+pushd /Users/kitware/Dashboards/ITK > /dev/null
+tar -cf ITKPythonBuilds-macosx.tar \
+  ITKPythonPackage/ITK-* \
+  ITKPythonPackage/standalone-* \
+  ITKPythonPackage/venvs \
+  ITKPythonPackageRequiredExtractionDir.txt \
+  ITKPythonPackage/scripts
+/usr/local/bin/zstd -f \
+  ./ITKPythonBuilds-macosx.tar \
+  -o ./ITKPythonBuilds-macosx.tar.zst
+popd > /dev/null

--- a/scripts/windows-build-tarball.ps1
+++ b/scripts/windows-build-tarball.ps1
@@ -1,0 +1,6 @@
+# This script creates a tarball of the ITK Python package build tree. It is
+# downloaded by the external module build scripts and used to build their
+# Python package on GitHub CI services.
+
+cd C:\P\
+C:\7-Zip\7z.exe a -r 'C:\P\ITKPythonBuilds-windows.zip' -w 'C:\P\IPP' -mem=AES256


### PR DESCRIPTION
These contain the ITK Python package build trees. ITK external module GitHub
CI builds download these tarballs and build against them.