### PR TITLE
manylinux: Update excluded Python versions

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -13,7 +13,7 @@ source "${script_dir}/manylinux-build-common.sh"
 
 # Compile wheels re-using standalone project and archive cache
 for PYBIN in "${PYBINARIES[@]}"; do
-    if [[ ${PYBIN} == *"cp26"* || ${PYBIN} == *"cp33"* ]]; then
+    if [[ ${PYBIN} == *"cp26"* || ${PYBIN} == *"cp33"* || ${PYBIN} == *"cp34"* || ${PYBIN} == *"cpython-2.6"* ]]; then
         echo "Skipping ${PYBIN}"
         continue
     fi


### PR DESCRIPTION
cp34 in no longer necessary for support because of low usage.

 cpython-2.6.9-ucs2  cpython-2.6.9-ucs4 were recently added to the manylinux
 image -- exclude them.