### PR TITLE
Revert "macpython: Disable delocate for module wheel builds"

### DIFF
--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -64,7 +64,5 @@ for VENV in "${VENVS[@]}"; do
     ${PYTHON_EXECUTABLE} setup.py clean
 done
 
-# Temporarily disabled. See Issue
-# @InsightSoftwareConsortium/ITKPythonPackage#78
-#${DELOCATE_LISTDEPS} $PWD/dist/*.whl # lists library dependencies
-#${DELOCATE_WHEEL} $PWD/dist/*.whl # copies library dependencies into wheel
+${DELOCATE_LISTDEPS} $PWD/dist/*.whl # lists library dependencies
+${DELOCATE_WHEEL} $PWD/dist/*.whl # copies library dependencies into wheel


### PR DESCRIPTION
This reverts commit 3ba3aeb10e174ac630f28e9e172fa5dd4ce1183c.

Addresses #80