### PR TITLE
WIP: Remove support for Python 2.7 on Windows

### DIFF
--- a/docs/Build_ITK_Module_Python_packages.rst
+++ b/docs/Build_ITK_Module_Python_packages.rst
@@ -109,7 +109,7 @@ Then, build the wheels::
 Windows
 -------
 
-First, install Microsoft Visual C++ Compiler for Python 2.7, Visual Studio 2015, Git, and CMake, which should be added to the system PATH environmental variable.
+First, install Microsoft Visual Studio 2015, Git, and CMake, which should be added to the system PATH environmental variable.
 
 Open a PowerShell terminal as Administrator, and install Python::
 

--- a/docs/Build_ITK_Python_packages.rst
+++ b/docs/Build_ITK_Python_packages.rst
@@ -60,7 +60,7 @@ Then, build the wheels::
 Windows
 -------
 
-First, install Microsoft Visual C++ Compiler for Python 2.7, Visual Studio 2015, Git, and CMake, which should be added to the system PATH environmental variable.
+First, install Microsoft Visual Studio 2015, Git, and CMake, which should be added to the system PATH environmental variable.
 
 Open a PowerShell terminal as Administrator, and install Python::
 
@@ -81,7 +81,6 @@ In a PowerShell prompt::
 
 	    Mode                LastWriteTime         Length Name
 	    ----                -------------         ------ ----
-	    -a----         4/9/2017   5:21 PM       59435508 itk-4.11.0.dev20170407-cp27-cp27m-win_amd64.whl
 	    -a----         4/9/2017  11:14 PM       63274441 itk-4.11.0.dev20170407-cp35-cp35m-win_amd64.whl
 	    -a----        4/10/2017   2:08 AM       63257220 itk-4.11.0.dev20170407-cp36-cp36m-win_amd64.whl
 

--- a/scripts/internal/windows_build_common.py
+++ b/scripts/internal/windows_build_common.py
@@ -3,7 +3,7 @@ __all__ = ['DEFAULT_PY_ENVS', 'venv_paths']
 from subprocess import check_call
 import os
 
-DEFAULT_PY_ENVS = ["27-x64", "35-x64", "36-x64"]
+DEFAULT_PY_ENVS = ["35-x64", "36-x64"]
 
 SCRIPT_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
@@ -32,7 +32,7 @@ def venv_paths(python_version):
     pip = os.path.join(venv_dir, "Scripts", "pip.exe")
 
     ninja_executable = os.path.join(
-        ROOT_DIR, "venv-27-x64", "Scripts", "ninja.exe")
+        ROOT_DIR, "venv-35-x64", "Scripts", "ninja.exe")
     print("NINJA_EXECUTABLE:%s" % ninja_executable)
 
     # Update PATH

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -9,4 +9,4 @@ sz x doxygen-1.8.11.windows.bin.zip -oC:\P\doxygen -aoa -r
 Invoke-WebRequest -Uri "https://midas3.kitware.com/midas/download/bitstream/462235/grep-win.zip" -OutFile "grep-win.zip"
 sz x grep-win.zip -oC:\P\grep -aoa -r
 $env:Path += ";C:\P\grep"
-C:\Python27-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py
+C:\Python35-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py

--- a/scripts/windows_build_wheels.py
+++ b/scripts/windows_build_wheels.py
@@ -226,14 +226,13 @@ def test_wheels(single_wheel=False):
 def build_wheels(py_envs=DEFAULT_PY_ENVS, single_wheel=False,
                  cleanup=False, wheel_names=None):
 
-    prepare_build_env("27-x64")
     prepare_build_env("35-x64")
     prepare_build_env("36-x64")
 
     with push_dir(directory=STANDALONE_DIR, make_directory=True):
 
         cmake_executable = "cmake.exe"
-        tools_venv = os.path.join(ROOT_DIR, "venv-27-x64")
+        tools_venv = os.path.join(ROOT_DIR, "venv-35-x64")
         pip_install(tools_venv, "ninja")
         ninja_executable = os.path.join(tools_venv, "Scripts", "ninja.exe")
 


### PR DESCRIPTION
ITKv5 will require C++11. On Windows, to compile ITK to work with Python2.7
from Python.org, one needs to use Visual Studio C++ 2008 which does not
support C++11. Therefore ITK will not be built on Windows for Python 2.7
anymore.