### PR TITLE
macpython: Update CMAKE_OSX_DEPLOYMENT_TARGET to 10.9

### DIFF
--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -48,13 +48,13 @@ for VENV in "${VENVS[@]}"; do
     ${PYTHON_EXECUTABLE} -m pip install --no-cache ninja
     NINJA_EXECUTABLE=${VENV}/bin/ninja
     itk_build_path="${SCRIPT_DIR}/../ITK-${py_mm}-macosx_x86_64"
-    ${PYTHON_EXECUTABLE} setup.py bdist_wheel --build-type MinSizeRel --plat-name macosx-10.6-x86_64 -G Ninja -- \
+    ${PYTHON_EXECUTABLE} setup.py bdist_wheel --build-type MinSizeRel --plat-name macosx-10.9-x86_64 -G Ninja -- \
       -DCMAKE_MAKE_PROGRAM:FILEPATH=${NINJA_EXECUTABLE} \
       -DITK_DIR:PATH=${itk_build_path} \
       -DITK_USE_SYSTEM_SWIG:BOOL=ON \
       -DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel \
       -DSWIG_EXECUTABLE:FILEPATH=${itk_build_path}/Wrapping/Generators/SwigInterface/swig/bin/swig \
-      -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.6 \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9 \
       -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 \
       -DBUILD_TESTING:BOOL=OFF \
       -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE} \

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -75,8 +75,8 @@ for VENV in "${VENVS[@]}"; do
     ${PYTHON_EXECUTABLE} -m pip install --upgrade -r ${SCRIPT_DIR}/../requirements-dev.txt
 
     build_type="MinSizeRel"
-    plat_name="macosx-10.6-x86_64"
-    osx_target="10.6"
+    plat_name="macosx-10.9-x86_64"
+    osx_target="10.9"
     source_path=${SCRIPT_DIR}/../standalone-build/ITK-source
     build_path="${SCRIPT_DIR}/../ITK-${py_mm}-macosx_x86_64"
     SETUP_PY_CONFIGURE="${script_dir}/setup_py_configure.py"


### PR DESCRIPTION
ITK 5 will require C++11. OSX_DEPLOYMENT_TARGET set to 10.9 uses libc++
instead of libstdc++ by default, which has sufficient C++11.