### PR TITLE
docs: Do not sign generated wheels

### DIFF
--- a/docs/Build_ITK_Module_Python_packages.rst
+++ b/docs/Build_ITK_Module_Python_packages.rst
@@ -146,11 +146,6 @@ Next, create a `~/.pypirc` file with your login credentials::
 
 where `<your-username>` and `<your-password>` correspond to your PyPI account.
 
-If you have a `GPG signing key
-<https://help.github.com/articles/generating-a-new-gpg-key/>`_, sign the wheels::
-
-  for whl in dist/*.whl; do gpg --detach-sign -a $whl; done
-
 Then, upload wheels to the testing server::
 
   python -m pip install twine


### PR DESCRIPTION
The signing was not verified, and signing is being removed from the
Python packaging tools.