### PR TITLE
windows: unsigned short pixel type specification in wrong build script

### DIFF
--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -48,7 +48,6 @@ def build_wheels(py_envs=DEFAULT_PY_ENVS):
                 "-DITK_DIR:PATH=%s" % itk_build_path,
                 "-DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel",
                 "-DSWIG_EXECUTABLE:FILEPATH=%s/Wrapping/Generators/SwigInterface/swig/bin/swig.exe" % itk_build_path,
-                "-DITK_WRAP_unsigned_short:BOOL=ON",
                 "-DBUILD_TESTING:BOOL=OFF",
                 "-DPYTHON_EXECUTABLE:FILEPATH=%s" % python_executable,
                 "-DPYTHON_INCLUDE_DIR:PATH=%s" % python_include_dir,

--- a/scripts/windows_build_wheels.py
+++ b/scripts/windows_build_wheels.py
@@ -88,6 +88,7 @@ def build_wrapped_itk(
             "-DITK_BINARY_DIR:PATH=%s" % build_path,
             "-DBUILD_TESTING:BOOL=OFF",
             "-DPYTHON_EXECUTABLE:FILEPATH=%s" % python_executable,
+            "-DITK_WRAP_unsigned_short:BOOL=ON",
             "-DPYTHON_INCLUDE_DIR:PATH=%s" % python_include_dir,
             "-DPYTHON_LIBRARY:FILEPATH=%s" % python_library,
             "-DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel",


### PR DESCRIPTION
This should be in the primary ITK build script, not the module build script.