### PR TITLE
windows: Do not install Python on AppVeyor

### DIFF
--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -1,7 +1,7 @@
 trap { Write-Error $_; Exit 1 }
 
 set-alias sz "$env:ProgramFiles\7-Zip\7z.exe"
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
+if (-not (Test-Path env:APPVEYOR)) { iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1')) }
 if (-not (Test-Path env:ITK_PACKAGE_VERSION)) { $env:ITK_PACKAGE_VERSION = 'v5.0b01' }
 Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/$env:ITK_PACKAGE_VERSION/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
 sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r


### PR DESCRIPTION
It is already installed. This now resulting in the AppVeyor build error:

47 Installing pip using C:\Python35-x86\python.exe
48C:\projects\itkmorphologicalcontourinterpolation\windows-download-cache-and-build-module-wheels.ps1 : This command cannot be run due to the error: The system cannot find the file specified.
49At line:1 char:1
50+ .\windows-download-cache-and-build-module-wheels.ps1
51+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
52    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
53    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,windows-download-cache-and-build-module-wheels.ps1
54
55
56
57Command executed with exception: This command cannot be run due to the error: The system cannot find the file specified.