### PR TITLE
windows-download-script: Download grep-win.zip from data.kitware.com

### DIFF
--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -7,7 +7,9 @@ Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBu
 sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 Invoke-WebRequest -Uri "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11.windows.bin.zip" -OutFile "doxygen-1.8.11.windows.bin.zip"
 sz x doxygen-1.8.11.windows.bin.zip -oC:\P\doxygen -aoa -r
-Invoke-WebRequest -Uri "https://midas3.kitware.com/midas/download/bitstream/462235/grep-win.zip" -OutFile "grep-win.zip"
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -OutFile "grep-win.zip"
 sz x grep-win.zip -oC:\P\grep -aoa -r
 $env:Path += ";C:\P\grep"
 C:\Python35-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py


### PR DESCRIPTION
midas3.kitware.com is no longer available.

The SSL configuration required is explained here:

  https://stackoverflow.com/questions/36265534/invoke-webrequest-ssl-fails

Closes #112 