### PR TITLE
scripts: Enable TLS2 for GitHub downloads in PowerShell script

### DIFF
--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -1,4 +1,6 @@
 trap { Write-Error $_; Exit 1 }
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
 
 set-alias sz "$env:ProgramFiles\7-Zip\7z.exe"
 if (-not (Test-Path env:APPVEYOR)) { iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1')) }
@@ -7,8 +9,6 @@ Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBu
 sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 Invoke-WebRequest -Uri "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11.windows.bin.zip" -OutFile "doxygen-1.8.11.windows.bin.zip"
 sz x doxygen-1.8.11.windows.bin.zip -oC:\P\doxygen -aoa -r
-$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
-[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
 Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -OutFile "grep-win.zip"
 sz x grep-win.zip -oC:\P\grep -aoa -r
 $env:Path += ";C:\P\grep"


### PR DESCRIPTION
Avoid errors related to unsupported protocol.

@jcfr FYI, we need this now for GitHub in addition to data.kitware.com.