### PR TITLE
COMP: Use a shorter ExternalProject prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if(ITKPythonPackage_SUPERBUILD)
 
   if(NOT DEFINED ITK_SOURCE_DIR)
 
-    set(ITK_SOURCE_DIR ${CMAKE_BINARY_DIR}/ITK-source)
+    set(ITK_SOURCE_DIR ${CMAKE_BINARY_DIR}/ITKs)
 
     ExternalProject_add(ITK-source-download
       SOURCE_DIR ${ITK_SOURCE_DIR}
@@ -158,7 +158,7 @@ if(ITKPythonPackage_SUPERBUILD)
 
   option(ITKPythonPackage_ITK_BINARY_REUSE "Reuse provided ITK_BINARY_DIR without configuring or building ITK" OFF)
 
-  set(ITK_BINARY_DIR "${CMAKE_BINARY_DIR}/ITK-build" CACHE PATH "ITK build directory")
+  set(ITK_BINARY_DIR "${CMAKE_BINARY_DIR}/ITKb" CACHE PATH "ITK build directory")
 
   message(STATUS "SuperBuild -")
   message(STATUS "SuperBuild - ITK => Requires ITK-source-download")
@@ -181,6 +181,7 @@ if(ITKPythonPackage_SUPERBUILD)
       DOWNLOAD_COMMAND ""
       SOURCE_DIR ${ITK_SOURCE_DIR}
       BINARY_DIR ${ITK_BINARY_DIR}
+      PREFIX "ITKp"
       CMAKE_CACHE_ARGS
         -DBUILD_TESTING:BOOL=OFF
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
To address:

CMake Error at CMakeLists.txt:84 (message):
  ITK source code directory path length is too long (54 > 50).Please move the
  ITK source code directory to a directory with a shorter path.

-- Configuring incomplete, errors occurred!
See also "C:/P/IPP/_skbuild/win-amd64-3.5/cmake-build/ITK-build/CMakeFiles/CMakeOutput.log".
FAILED: ITK-prefix/src/ITK-stamp/ITK-configure
cmd.exe /C "cd /D C:\P\IPP\_skbuild\win-amd64-3.5\cmake-build\ITK-build && C:\P\IPP\venv-35-x64\Lib\site-packages\cmake\data\bin\cmake.exe -CC:/P/IPP/_skbuild/win-amd64-3.5/cmake-build/ITK-prefix/tmp/ITK-cache-Release.cmake -GNinja C:/P/IPP/_skbuild/win-amd64-3.5/cmake-build/ITK-source && C:\P\IPP\venv-35-x64\Lib\site-packages\cmake\data\bin\cmake.exe -E touch C:/P/IPP/_skbuild/win-amd64-3.5/cmake-build/ITK-prefix/src/ITK-stamp/ITK-configure"

And similar errors for the build tree.