### PR TITLE
cmake: Fix missing `find_package(Doxygen)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ if(ITKPythonPackage_SUPERBUILD)
   if(DEFINED PYTHON_EXECUTABLE AND NOT EXISTS ${PYTHON_EXECUTABLE})
     message(FATAL_ERROR "PYTHON_EXECUTABLE variable is defined but corresponds to nonexistent file")
   endif()
+  if(DEFINED DOXYGEN_EXECUTABLE AND NOT EXISTS ${DOXYGEN_EXECUTABLE})
+    message(FATAL_ERROR "DOXYGEN_EXECUTABLE variable is defined but corresponds to nonexistent file")
+  endif()
 
   if(NOT DEFINED PYTHON_INCLUDE_DIR
      OR NOT DEFINED PYTHON_LIBRARY
@@ -145,6 +148,9 @@ if(ITKPythonPackage_SUPERBUILD)
     find_package ( PythonLibs REQUIRED )
     find_package ( PythonInterp REQUIRED )
 
+  endif()
+  if(NOT DEFINED DOXYGEN_EXECUTABLE)
+    find_package(Doxygen REQUIRED)
   endif()
 
   message(STATUS "SuperBuild -   PYTHON_INCLUDE_DIR: ${PYTHON_INCLUDE_DIR}")


### PR DESCRIPTION
When installing ITK from source (sdist), the CMakeLists.txt
file provided at the root of the project is used. This CMakeLists.txt file
uses the CMake variable `DOXYGEN_EXECUTABLE` assuming that it has been set
,which is the case when compiling ITKPythonPackage using the scripts available
in the `scripts` subdirectory. However, when building ITK from source, this
value was not set and compilation was failing with the following error message:

  `Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)`