### PR TITLE
Build only 64-bit wheels

### DIFF
--- a/docs/Build_ITK_Module_Python_packages.rst
+++ b/docs/Build_ITK_Module_Python_packages.rst
@@ -115,6 +115,7 @@ First, install Microsoft Visual Studio 2015, Git, and CMake, which should be add
 Open a PowerShell terminal as Administrator, and install Python::
 
 	PS C:\> Set-ExecutionPolicy Unrestricted
+	PS C:\> $pythonArch = "64"
 	PS C:\> iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 
 In a PowerShell prompt, run the `windows-build-wheels.ps1` script::

--- a/docs/Build_ITK_Python_packages.rst
+++ b/docs/Build_ITK_Python_packages.rst
@@ -65,6 +65,7 @@ First, install Microsoft Visual Studio 2015, Git, and CMake, which should be add
 Open a PowerShell terminal as Administrator, and install Python::
 
 	PS C:\> Set-ExecutionPolicy Unrestricted
+	PS C:\> $pythonArch = "64"
 	PS C:\> iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 
 In a PowerShell prompt::

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -3,7 +3,10 @@ $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
 [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
 
 set-alias sz "$env:ProgramFiles\7-Zip\7z.exe"
-if (-not (Test-Path env:APPVEYOR)) { iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1')) }
+if (-not (Test-Path env:APPVEYOR)) {
+  $pythonArch = "64"
+  iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1')) 
+}
 if (-not (Test-Path env:ITK_PACKAGE_VERSION)) { $env:ITK_PACKAGE_VERSION = 'v5.0rc01' }
 Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/$env:ITK_PACKAGE_VERSION/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
 sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r


### PR DESCRIPTION
This commit works around issue building ITKModuleTemplate wheels on
Azure Pipelines where 32-bit install of python is failing when using the
script provided by scikit-ci-addons.

See https://dev.azure.com/InsightSoftwareConsortium/ITKModules/_build/results?buildId=322