### PR TITLE
scripts: install itkHelpers.py

### DIFF
--- a/scripts/setup_py_configure.py
+++ b/scripts/setup_py_configure.py
@@ -245,6 +245,7 @@ ITK_SETUP_PY_PARAMETERS = {
         'itkBase',
         'itkConfig',
         'itkExtras',
+        'itkHelpers',
         'itkLazy',
         'itkTemplate',
         'itkTypes',


### PR DESCRIPTION
The Python file `itkHelpers.py` has been added recently to ITK but it
was not installed correctly with ITKPythonPackage. This commit
addresses this omission and should address ITKPythonPackage
issue #128 .