### PR TITLE
requirements: Pin scikit-build version to 0.8.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-scikit-build>=0.5.1
+scikit-build==0.8.1
 numpy


### PR DESCRIPTION
Required until https://github.com/scikit-build/scikit-build/issues/415
is addressed.