### PR TITLE
ENH: We now always depend on numpy, so specify that in setup.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,8 @@ if(ITKPythonPackage_SUPERBUILD)
 
   set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
 
-  # ITK release 2021-04-28
-  set(ITK_GIT_TAG "fa36932038fc81d57ea161600ba4fa605d252487")
+  # ITK release 2021-05-05
+  set(ITK_GIT_TAG "f3108c7513ee18f31a12fb088bb8990fb6aae0bc")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused

--- a/itkVersion.py
+++ b/itkVersion.py
@@ -1,4 +1,4 @@
-VERSION = '5.2.0.post1'
+VERSION = '5.2.0.post2'
 
 def get_versions():
     """Returns versions for the ITK Python package.

--- a/scripts/setup_py_configure.py
+++ b/scripts/setup_py_configure.py
@@ -182,12 +182,15 @@ def update_wheel_setup_py_parameters():
             '-DITKPythonPackage_WHEEL_NAME:STRING=%s' % wheel_name
         ])
 
+        # install_requires
+        wheel_depends = get_wheel_dependencies()[wheel_name]
+
         # py_modules
         if wheel_name != 'itk-core':
             params['SETUP_PY_MODULES'] = r''
+        else:
+            wheel_depends.append('numpy')
 
-        # install_requires
-        wheel_depends = get_wheel_dependencies()[wheel_name]
         params['SETUP_INSTALL_REQUIRES'] = list_to_str(wheel_depends)
 
         SETUP_PY_PARAMETERS[wheel_name] = params

--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,6 @@ setup(
     keywords='ITK InsightToolkit segmentation registration image imaging',
     url=r'https://itk.org/',
     install_requires=[
+        r'numpy',
     ]
     )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 
-# Generated using: python setup_py_configure.py 'itk-meta'
+# Generated using: python setup_py_configure.py 'itk'
 
 from __future__ import print_function
 from os import sys, path
@@ -16,19 +16,14 @@ except ImportError:
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 from itkVersion import get_versions
 
-long_description = 'itk\n'
-long_description += '====================================\n\n'
-long_description += 'ITK is an open-source, cross-platform library that provides developers with an extensive suite of software tools for image analysis. Developed through extreme programming methodologies, ITK employs leading-edge algorithms for registering and segmenting multidimensional scientific images.\n\n'
-
 this_directory = path.abspath(path.dirname(__file__))
 itk_readme_path = path.join(this_directory, 'ITK-source', 'ITK', 'README.md')
 if path.exists(itk_readme_path):
     with open(itk_readme_path, encoding='utf-8') as f:
-        long_description += f.read()
+        long_description = f.read()
 else:
     with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-        long_description += f.read()
-
+        long_description = f.read()
 
 setup(
     name='itk',
@@ -37,8 +32,17 @@ setup(
     author_email='community@itk.org',
     packages=['itk'],
     package_dir={'itk': 'itk'},
-    cmake_args=['-DITKPythonPackage_WHEEL_NAME:STRING=itk-meta'],
-    py_modules=[],
+    cmake_args=[],
+    py_modules=[
+        'itkBase',
+        'itkConfig',
+        'itkExtras',
+        'itkLazy',
+        'itkTemplate',
+        'itkTypes',
+        'itkVersion',
+        'itkBuildOptions'
+    ],
     download_url=r'https://itk.org/ITK/resources/software.html',
     description=r'ITK is an open-source toolkit for multidimensional image analysis',
     long_description=long_description,
@@ -66,12 +70,5 @@ setup(
     keywords='ITK InsightToolkit segmentation registration image imaging',
     url=r'https://itk.org/',
     install_requires=[
-        'itk-core==5.2.0.post1',
-        'itk-numerics==5.2.0.post1',
-        'itk-io==5.2.0.post1',
-        'itk-filtering==5.2.0.post1',
-        'itk-registration==5.2.0.post1',
-        'itk-segmentation==5.2.0.post1',
-        'numpy'
     ]
     )


### PR DESCRIPTION
I think we need numpy 1.20 for typing, which in turn requires Python 3.7+. Should we also add a note to main ITK repo that Python 3.6 is no longer supported?