### PR TITLE
ENH: Add cross platform options for wheel repair with shared libraries

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Run this script inside a dockcross container to build Python wheels for an ITK module
+
 # -----------------------------------------------------------------------
 # These variables are set in common script:
 #
@@ -10,8 +12,9 @@ script_dir=$(cd $(dirname $0) || exit 1; pwd)
 source "${script_dir}/manylinux-build-common.sh"
 # -----------------------------------------------------------------------
 
-# So auditwheel can find the libs
-export LD_LIBRARY_PATH=/work/oneTBB-prefix/lib64
+# Set up library paths in container so that shared libraries can be added to wheels
+sudo ldconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
 # Compile wheels re-using standalone project and archive cache
 for PYBIN in "${PYBINARIES[@]}"; do

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -20,7 +20,8 @@ pushd /work/ITK-source > /dev/null 2>&1
 popd > /dev/null 2>&1
 tbb_dir=/work/oneTBB-prefix/lib64/cmake/TBB
 # So auditwheel can find the libs
-export LD_LIBRARY_PATH=/work/oneTBB-prefix/lib64
+sudo ldconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib64:/usr/lib:/usr/lib64
 
 SINGLE_WHEEL=0
 

--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -26,7 +26,7 @@ ${Python3_EXECUTABLE} -m pip install --no-cache delocate
 DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
 DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
 # So delocate can find the libs
-export DYLD_LIBRARY_PATH=${script_dir}/../oneTBB-prefix/lib
+export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${script_dir}/../oneTBB-prefix/lib
 
 # Compile wheels re-using standalone project and archive cache
 for VENV in "${VENVS[@]}"; do
@@ -66,7 +66,7 @@ for VENV in "${VENVS[@]}"; do
       -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
       -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
     || exit 1
-    ${Python3_EXECUTABLE} setup.py clean
+    # ${Python3_EXECUTABLE} setup.py clean    # Permission denied
 done
 
 for wheel in $PWD/dist/*.whl; do

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -44,7 +44,7 @@ DELOCATE_PATCH=${VENV}/bin/delocate-patch
 # Build standalone project and populate archive cache
 tbb_dir=$PWD/oneTBB-prefix/lib/cmake/TBB
 # So delocate can find the libs
-export DYLD_LIBRARY_PATH=$PWD/oneTBB-prefix/lib
+export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:$PWD/oneTBB-prefix/lib
 mkdir -p ITK-source
 pushd ITK-source > /dev/null 2>&1
   ${CMAKE_EXECUTABLE} -DITKPythonPackage_BUILD_PYTHON:PATH=0 \


### PR DESCRIPTION
Update Python build scripts to allow the generated Python module wheel to be repackaged to include shared library dependencies such as TBB or OpenCL. This is carried out with `auditwheel` (Linux), `delocate` (macOS), or `delvewheel` (Windows).

Example syntax for packaging a module with a dependency on OpenCL shared libraries:

Windows:
```
C:\Python38-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "38-x64" --lib-paths "/path/to/OpenCL/directory;/path/to/other/libraries" --no-cleanup -- "-DOpenCL_INCLUDE_DIR:PATH=/path/to/OpenCL/include/dir" "-DOpenCL_LIBRARY:FILEPATH=/path/to/OpenCL.lib"
```

Linux:
```
export LD_LIBRARY_PATH="/path/to/OpenCL/directory:/path/to/other/libraries"
./dockcross-manylinux-download-cache-and-build-module-wheels.sh "cp38" 
```

macOS:
```
export DYLD_LIBRARY_PATH="/path/to/OpenCL/directory:/path/to/other/libraries""
./macpython-download-cache-and-build-module-wheels.sh
```

Will close #165 .