### PR TITLE
BUG: Define DELOCATE_PATCH in macpython-build-module-wheels.sh

### DIFF
--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -3,18 +3,15 @@
 # Run this script to build the Python wheel packages for macOS for an ITK
 # external module.
 #
-# Versions can be restricted by passing them in as arguments to the script
-# For example,
-#
-#   scripts/macpython-build-module-wheels.sh 2.7 3.5
+# Versions can be restricted by passing them in as arguments to the script.
 #
 # Shared libraries can be included in the wheel by exporting them to DYLD_LIBRARY_PATH before
 # running this script.
-# 
+#
 # For example,
 #
 #   export DYLD_LIBRARY_PATH="/path/to/libs"
-#   scripts/macpython-build-module-wheels.sh cp39
+#   scripts/macpython-build-module-wheels.sh 3.7 3.9
 #
 
 # -----------------------------------------------------------------------
@@ -34,6 +31,7 @@ Python3_EXECUTABLE=${VENV}/bin/python3
 ${Python3_EXECUTABLE} -m pip install --no-cache delocate
 DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
 DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
+DELOCATE_PATCH=${VENV}/bin/delocate-patch
 # So delocate can find the libs
 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${script_dir}/../oneTBB-prefix/lib
 


### PR DESCRIPTION
Addresses "Permission denied" error.