### PR TITLE
BUG: Fix hash for ITK v5.3rc02

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(ITKPythonPackage_SUPERBUILD)
   set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
 
   # ITK release 2021-10-27
-  set(ITK_GIT_TAG "30cd5fa095a6b2e52fac052e4a84bb3740fcc2b1")
+  set(ITK_GIT_TAG "4c25e667a59d9f581e45576d80b25342df19fd5d")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused


### PR DESCRIPTION
ITK v5.3rc02 tag: [https://github.com/InsightSoftwareConsortium/ITK//tree/4c25e667a5](https://github.com/InsightSoftwareConsortium/ITK//tree/4c25e667a5)

Failures from building against old (v5.3rc01) ITK source as a result of the old tag: [https://github.com/KitwareMedical/ITKUltrasound/pull/161](https://github.com/KitwareMedical/ITKUltrasound/pull/161)