### PR TITLE
BUG: Update tag for v5.3 RC 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(ITKPythonPackage_SUPERBUILD)
   set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
 
   # ITK release 2021-10-27
-  set(ITK_GIT_TAG "4c25e667a59d9f581e45576d80b25342df19fd5d")
+  set(ITK_GIT_TAG "v5.3rc02")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused

--- a/itkVersion.py
+++ b/itkVersion.py
@@ -1,4 +1,4 @@
-VERSION = '5.3rc2'
+VERSION = '5.3rc2.post1'
 
 def get_versions():
     """Returns versions for the ITK Python package.


### PR DESCRIPTION
Use the tag directly and bump the Python package version for a new release.