### PR TITLE
BUG: Rename module __init__ file after repairing windows module wheel

### DIFF
--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -7,6 +7,7 @@ import os
 import glob
 import sys
 import argparse
+import shutil
 
 SCRIPT_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.abspath(os.getcwd())
@@ -18,6 +19,19 @@ sys.path.insert(0, os.path.join(SCRIPT_DIR, "internal"))
 
 from wheel_builder_utils import push_dir, push_env
 from windows_build_common import DEFAULT_PY_ENVS, venv_paths
+
+def install_and_import(package):
+    """
+    Install package with pip and import in current script.
+    """
+    import importlib
+    try:
+        importlib.import_module(package)
+    except ImportError:
+        import pip
+        pip.main(['install', package])
+    finally:
+        globals()[package] = importlib.import_module(package)
 
 def build_wheels(py_envs=DEFAULT_PY_ENVS, cleanup=True, cmake_options=[]):
     for py_env in py_envs:
@@ -64,6 +78,34 @@ def build_wheels(py_envs=DEFAULT_PY_ENVS, cleanup=True, cmake_options=[]):
             if cleanup:
                 check_call([python_executable, "setup.py", "clean"])
 
+def rename_wheel_init(py_env, filepath):
+    """
+    Rename module __init__ file in wheel.
+    This is required to prevent modules to override ITK's __init__ file on install.
+    If the module ships its own __init__ file, it is automatically renamed to
+    __init_{module_name}__ by this function. The renamed __init__ file will be executed
+    by ITK's __init__ file when loading ITK.
+    """
+    python_executable, python_include_dir, python_library, pip, ninja_executable, path = venv_paths(py_env)
+
+    # Get module info
+    install_and_import("pkginfo")
+    w = pkginfo.Wheel(filepath)
+    module_name = w.name.split("itk-")[-1]
+    module_version = w.version
+
+    dist_dir = os.path.dirname(filepath)
+    wheel_dir = os.path.join(dist_dir, "itk_" + module_name + "-" + module_version)
+    init_dir = os.path.join(wheel_dir, "itk")
+    init_file = os.path.join(init_dir, "__init__.py")
+
+    # Unpack wheel and rename __init__ file if it exists.
+    check_call([python_executable, "-m", "wheel", "unpack", filepath, "-d", dist_dir])
+    if os.path.isfile(init_file):
+        shutil.move(init_file, os.path.join(init_dir, "__init_" + module_name + "__.py"))
+    # Pack wheel and clean wheel folder
+    check_call([python_executable, "-m", "wheel", "pack", wheel_dir, "-d", dist_dir])
+    shutil.rmtree(wheel_dir)
 
 def fixup_wheel(py_envs, filepath, lib_paths:str=''):
     lib_paths = ';'.join(["C:/P/IPP/oneTBB-prefix/bin",lib_paths.strip()]).strip(';')
@@ -76,6 +118,10 @@ def fixup_wheel(py_envs, filepath, lib_paths:str=''):
         lib_paths, "--ignore-in-wheel", "-w",
         os.path.join(ROOT_DIR, "dist"), filepath])
 
+    # The delve_wheel patch loading shared libraries is added to the module
+    # __init__ file. Rename this file here to prevent conflicts on installation.
+    # The renamed __init__ file will be executed when loading ITK.
+    rename_wheel_init(py_env, filepath)
 
 def fixup_wheels(py_envs, lib_paths:str=''):
     # shared library fix-up


### PR DESCRIPTION
When repairing wheels on windows, the delve_wheel patch loading dlls is appended to the module __init__ file. Upon installation, this module __init__ file overrides ITK's __init__ file. Rename the module file to prevent conflicts.
ITK's __init__ file takes care of executing the renamed module file.