### PR TITLE
ENH: Enable wrapping for complex double type by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ if(ITKPythonPackage_SUPERBUILD)
         -DITK_WRAP_PYTHON:BOOL=ON
         -DITK_WRAP_unsigned_short:BOOL=ON
         -DITK_WRAP_double:BOOL=ON
+        -DITK_WRAP_complex_double:BOOL=ON
         -DITK_WRAP_IMAGE_DIMS:STRING=2;3;4
         -DITK_WRAP_DOC:BOOL=ON
         -DDOXYGEN_EXECUTABLE:FILEPATH=${DOXYGEN_EXECUTABLE}


### PR DESCRIPTION
In most cases where the `double` pixel type is required we also want to enable `complex<double>` wrappings for filters dealing with complex types, such as FFT filters.

Partially addresses issue discussed in InsightSoftwareConsortium/ITK#2884 where building with ITKPythonPackage failed because FFT class wrappings assumed `complex<double>` is enabled if `double` is enabled. Subsequent fix will follow in ITK wrappings.