### PR TITLE
DOC: Restoring the example which demonstrated named parameters

### DIFF
--- a/docs/code/ImplicitInstantiation.py
+++ b/docs/code/ImplicitInstantiation.py
@@ -25,7 +25,7 @@ smoothed = itk.median_image_filter(image)
 ImageType = itk.Image[itk.UC, 2]
 reader = itk.ImageFileReader[ImageType].New(FileName=input_filename)
 # Here we specify the filter input explicitly
-median = itk.MedianImageFilter.New(reader.GetOutput())
+median = itk.MedianImageFilter.New(Input=reader.GetOutput())
 # Same as above but shortened. Input does not have to be specified.
 median = itk.MedianImageFilter.New(reader.GetOutput())
 # Same as above. .GetOutput() does not have to be specified.


### PR DESCRIPTION
Undoing a change which was part of 523327e5010a5dd380bac50e428a2e37b7479b63.