### PR TITLE
BUG: Remove zstd compression args incompatible with 1.2.0

### DIFF
--- a/scripts/dockcross-manylinux-build-tarball.sh
+++ b/scripts/dockcross-manylinux-build-tarball.sh
@@ -18,6 +18,5 @@ tar -c --to-stdout \
 $zstd_exe -f \
   -10 \
   -T6 \
-  --long=31 \
   ./ITKPythonBuilds-linux.tar \
   -o ./ITKPythonBuilds-linux.tar.zst

--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -7,7 +7,7 @@ brew update
 brew install zstd aria2 gnu-tar doxygen ninja
 brew upgrade cmake
 aria2c -c --file-allocation=none -o ITKPythonBuilds-macosx.tar.zst -s 10 -x 10 https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.2.0.post1}/ITKPythonBuilds-macosx.tar.zst
-unzstd ITKPythonBuilds-macosx.tar.zst -o ITKPythonBuilds-macosx.tar
+unzstd --long=31 ITKPythonBuilds-macosx.tar.zst -o ITKPythonBuilds-macosx.tar
 PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
 tar xf ITKPythonBuilds-macosx.tar --checkpoint=10000 --checkpoint-action=dot
 rm ITKPythonBuilds-macosx.tar


### PR DESCRIPTION
Comparing the `--help` output between zstd 1.2.0 and 1.5.2 shows that the `--long` option is not supported by the former. Without this option the Linux tarball compresses to 1.88 GiB which is less than the 2 GiB limit.

In the future we will need to upgrade the zstd version we are distributing to ITK external modules for building Python wheels so that they can take advantage of new, advanced compression flags. For now it seems we can stick with zstd 1.2.0.