### PR TITLE
Add support for multiple manylinux versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,10 @@ message(STATUS "SuperBuild - ITKPythonPackage_WHEEL_NAME:${ITKPythonPackage_WHEE
 
 option(ITKPythonPackage_USE_TBB "Build and use oneTBB in the ITK python package" ON)
 
-set(libpath "lib")
-if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-  set(libpath "lib64")
-endif()
 if(ITK_SOURCE_DIR)
-  set(TBB_DIR "${ITK_SOURCE_DIR}/../oneTBB-prefix/${libpath}/cmake/TBB")
+  set(TBB_DIR "${ITK_SOURCE_DIR}/../oneTBB-prefix/lib/cmake/TBB")
 else()
-  set(TBB_DIR "${CMAKE_BINARY_DIR}/../oneTBB-prefix/${libpath}/cmake/TBB")
+  set(TBB_DIR "${CMAKE_BINARY_DIR}/../oneTBB-prefix/lib/cmake/TBB")
 endif()
 set(tbb_args )
 if(ITKPythonPackage_USE_TBB)
@@ -116,6 +112,7 @@ if(ITKPythonPackage_SUPERBUILD)
         -DTBB_TEST:BOOL=OFF
         -DCMAKE_BUILD_TYPE:STRING=Release
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/../oneTBB-prefix
+        -DCMAKE_INSTALL_LIBDIR:STRING=lib # Skip default initialization by GNUInstallDirs CMake module
         ${ep_common_cmake_cache_args}
         -DCMAKE_BUILD_TYPE:STRING=Release
       BUILD_BYPRODUCTS "${TBB_DIR}/TBBConfig.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,10 @@ if(ITKPythonPackage_SUPERBUILD)
   #-----------------------------------------------------------------------------
   include(ExternalProject)
 
-  set(ITK_REPOSITORY "https://github.com/jcfr/ITK.git")
+  set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
 
-  # ITK update-from-manylinux2014-to-manylinux_2_24 2022-06-22
-  set(ITK_GIT_TAG "8ca6e8dc15")
+  # ITK nightly-master 2022-07-05
+  set(ITK_GIT_TAG "c44a7731f22bd5d241ac8f9369018671800f5cd9")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,10 @@ if(ITKPythonPackage_SUPERBUILD)
   #-----------------------------------------------------------------------------
   include(ExternalProject)
 
-  set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
+  set(ITK_REPOSITORY "https://github.com/jcfr/ITK.git")
 
-  # ITK nightly-master 2022-06-16
-  set(ITK_GIT_TAG "8b2a3d3fb3")
+  # ITK update-from-manylinux2014-to-manylinux_2_24 2022-06-22
+  set(ITK_GIT_TAG "8ca6e8dc15")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused

--- a/itkVersion.py
+++ b/itkVersion.py
@@ -1,4 +1,4 @@
-VERSION = '5.3rc03.dev20220616+486.g8b2a3d3fb3'
+VERSION = '5.3rc03.dev20220622+489.g8ca6e8dc15'
 
 def get_versions():
     """Returns versions for the ITK Python package.

--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -17,8 +17,8 @@
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
-MANYLINUX_VERSION=_2_24
-IMAGE_TAG=20220622-343dde5
+MANYLINUX_VERSION=_2_28
+IMAGE_TAG=20220705-b1eb184
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -17,8 +17,11 @@
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
+MANYLINUX_VERSION=2014
+IMAGE_TAG=20211011-a315bdc
+
 # Generate dockcross scripts
-docker run --rm dockcross/manylinux2014-x64:20211011-a315bdc > /tmp/dockcross-manylinux-x64
+docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64
 chmod u+x /tmp/dockcross-manylinux-x64
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)

--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -17,8 +17,8 @@
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
-MANYLINUX_VERSION=2014
-IMAGE_TAG=20211011-a315bdc
+MANYLINUX_VERSION=_2_24
+IMAGE_TAG=20220622-343dde5
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -7,8 +7,11 @@
 #
 #   scripts/dockcross-manylinux-build-wheels.sh cp39
 
+MANYLINUX_VERSION=2014
+IMAGE_TAG=20211011-a315bdc
+
 # Generate dockcross scripts
-docker run --rm dockcross/manylinux2014-x64:20211011-a315bdc > /tmp/dockcross-manylinux-x64
+docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64
 chmod u+x /tmp/dockcross-manylinux-x64
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -7,8 +7,8 @@
 #
 #   scripts/dockcross-manylinux-build-wheels.sh cp39
 
-MANYLINUX_VERSION=2014
-IMAGE_TAG=20211011-a315bdc
+MANYLINUX_VERSION=_2_24
+IMAGE_TAG=20220622-343dde5
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -7,8 +7,8 @@
 #
 #   scripts/dockcross-manylinux-build-wheels.sh cp39
 
-MANYLINUX_VERSION=_2_24
-IMAGE_TAG=20220622-343dde5
+MANYLINUX_VERSION=_2_28
+IMAGE_TAG=20220705-b1eb184
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -84,4 +84,6 @@ if ! type ninja > /dev/null 2>&1; then
   popd
 fi
 
-echo "Building wheels for $ARCH"
+MANYLINUX_VERSION=2014
+
+echo "Building wheels for $ARCH using manylinux${MANYLINUX_VERSION}"

--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -84,6 +84,6 @@ if ! type ninja > /dev/null 2>&1; then
   popd
 fi
 
-MANYLINUX_VERSION=2014
+MANYLINUX_VERSION=_2_24
 
 echo "Building wheels for $ARCH using manylinux${MANYLINUX_VERSION}"

--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # i686 or x86_64 ?
-case $(uname -p) in
+case $(uname -m) in
     i686)
         ARCH=x86
         ;;
@@ -39,13 +39,13 @@ case $(uname -p) in
         ARCH=aarch64
         ;;
     *)
-        die "Unknown architecture $(uname -p)"
+        die "Unknown architecture $(uname -m)"
         ;;
 esac
 
 # Install prerequirements
 export PATH=/work/tools/doxygen-1.8.11/bin:$PATH
-case $(uname -p) in
+case $(uname -m) in
     i686)
         ARCH=x86
         ;;
@@ -69,7 +69,7 @@ case $(uname -p) in
         fi
         ;;
     *)
-        die "Unknown architecture $(uname -p)"
+        die "Unknown architecture $(uname -m)"
         ;;
 esac
 if ! type ninja > /dev/null 2>&1; then

--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -4,10 +4,6 @@
 set -e -x
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)
-# Workaround broken FindPython3 in CMake 3.17
-if test -e /usr/share/cmake-3.17/Modules/FindPython/Support.cmake; then
-  sudo cp ${script_dir}/Support.cmake /usr/share/cmake-3.17/Modules/FindPython/
-fi
 
 # Versions can be restricted by passing them in as arguments to the script
 # For example,
@@ -44,7 +40,7 @@ case $(uname -m) in
 esac
 
 # Install prerequirements
-export PATH=/work/tools/doxygen-1.8.11/bin:$PATH
+export PATH=/work/tools/doxygen-1.8.16/bin:$PATH
 case $(uname -m) in
     i686)
         ARCH=x86
@@ -53,8 +49,8 @@ case $(uname -m) in
         if ! type doxygen > /dev/null 2>&1; then
           mkdir -p /work/tools
             pushd /work/tools > /dev/null 2>&1
-            curl https://data.kitware.com/api/v1/file/5c0aa4b18d777f2179dd0a71/download -o doxygen-1.8.11.linux.bin.tar.gz
-            tar -xvzf doxygen-1.8.11.linux.bin.tar.gz
+            curl https://data.kitware.com/api/v1/file/62c4d615bddec9d0c46cb705/download -o doxygen-1.8.16.linux.bin.tar.gz
+            tar -xvzf doxygen-1.8.16.linux.bin.tar.gz
           popd > /dev/null 2>&1
         fi
         ;;
@@ -63,8 +59,8 @@ case $(uname -m) in
         if ! type doxygen > /dev/null 2>&1; then
           mkdir -p /work/tools
             pushd /work/tools > /dev/null 2>&1
-            curl https://data.kitware.com/api/v1/file/6086e4b02fa25629b93ac66e/download -o doxygen-1.8.11.linux.aarch64.bin.tar.gz
-            tar -xvzf doxygen-1.8.11.linux.aarch64.bin.tar.gz
+            curl https://data.kitware.com/api/v1/file/62c4ed58bddec9d0c46f1388/download -o doxygen-1.8.16.linux.aarch64.bin.tar.gz
+            tar -xvzf doxygen-1.8.16.linux.aarch64.bin.tar.gz
           popd > /dev/null 2>&1
         fi
         ;;
@@ -84,6 +80,6 @@ if ! type ninja > /dev/null 2>&1; then
   popd
 fi
 
-MANYLINUX_VERSION=_2_24
+MANYLINUX_VERSION=_2_28
 
 echo "Building wheels for $ARCH using manylinux${MANYLINUX_VERSION}"

--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -78,8 +78,8 @@ for PYBIN in "${PYBINARIES[@]}"; do
     version=$(basename $(dirname ${PYBIN}))
     # Remove "m" -- not present in Python 3.8 and later
     version=${version:0:9}
-    itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
-    ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
+    itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux${MANYLINUX_VERSION}_${ARCH})
+    ln -fs /ITKPythonPackage/ITK-${version}*-manylinux${MANYLINUX_VERSION}_${ARCH} $itk_build_dir
     if [[ ! -d ${itk_build_dir} ]]; then
       echo 'ITK build tree not available!' 1>&2
       exit 1
@@ -117,6 +117,6 @@ if test "${ARCH}" == "x64"; then
 fi
 if compgen -G "dist/itk*-linux*.whl" > /dev/null; then
   for itk_wheel in dist/itk*-linux*.whl; do
-    mv ${itk_wheel} ${itk_wheel/linux/manylinux2014}
+    mv ${itk_wheel} ${itk_wheel/linux/manylinux${MANYLINUX_VERSION}}
   done
 fi

--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -61,7 +61,7 @@ source "${script_dir}/manylinux-build-common.sh"
 
 # Set up library paths in container so that shared libraries can be added to wheels
 sudo ldconfig
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
 # Compile wheels re-using standalone project and archive cache
 for PYBIN in "${PYBINARIES[@]}"; do

--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -95,7 +95,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
       -DITK_USE_SYSTEM_SWIG:BOOL=ON \
       -DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel \
       -DSWIG_EXECUTABLE:FILEPATH=${itk_build_dir}/Wrapping/Generators/SwigInterface/swig/bin/swig \
-      -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -p)-linux-gnu \
+      -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -m)-linux-gnu \
       -DBUILD_TESTING:BOOL=OFF \
       -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
       -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
@@ -108,7 +108,7 @@ if test "${ARCH}" == "x64"; then
   # Make sure auditwheel is installed for this python exe before importing
   # it in auditwheel_whitelist_monkeypatch.py
   sudo ${Python3_EXECUTABLE} -m pip install auditwheel
-  for whl in dist/*linux_$(uname -p).whl; do
+  for whl in dist/*linux_$(uname -m).whl; do
     # Repair wheel using monkey patch to exclude shared libraries provided in whitelist
     ${Python3_EXECUTABLE} "${script_dir}/auditwheel_whitelist_monkeypatch.py" \
       repair ${whl} -w /work/dist/ --whitelist "${EXCLUDE_LIBS}"

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -56,7 +56,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
     build_type="Release"
     compile_flags="-O3 -DNDEBUG"
     source_path=/work/ITK-source/ITK
-    build_path=/work/ITK-$(basename $(dirname ${PYBIN}))-manylinux2014_${ARCH}
+    build_path=/work/ITK-$(basename $(dirname ${PYBIN}))-manylinux${MANYLINUX_VERSION}_${ARCH}
     SETUP_PY_CONFIGURE="${script_dir}/../setup_py_configure.py"
     SKBUILD_CMAKE_INSTALL_PREFIX=$(${Python3_EXECUTABLE} -c "from skbuild.constants import CMAKE_INSTALL_DIR; print(CMAKE_INSTALL_DIR)")
 
@@ -167,9 +167,9 @@ done
 
 if test "${ARCH}" == "x64"; then
   sudo /opt/python/cp39-cp39/bin/pip3 install auditwheel wheel
-  # This step will fixup the wheel switching from 'linux' to 'manylinux2014' tag
+  # This step will fixup the wheel switching from 'linux' to 'manylinux<version>' tag
   for whl in dist/itk_*linux_$(uname -p).whl; do
-      /opt/python/cp39-cp39/bin/auditwheel repair --plat manylinux2014_x86_64 ${whl} -w /work/dist/
+      /opt/python/cp39-cp39/bin/auditwheel repair --plat manylinux${MANYLINUX_VERSION}_x86_64 ${whl} -w /work/dist/
       rm ${whl}
   done
 else

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -34,10 +34,10 @@ pushd /work/ITK-source > /dev/null 2>&1
   cmake -DITKPythonPackage_BUILD_PYTHON:PATH=0 -G Ninja ../
   ninja
 popd > /dev/null 2>&1
-tbb_dir=/work/oneTBB-prefix/lib64/cmake/TBB
+tbb_dir=/work/oneTBB-prefix/lib/cmake/TBB
 # So auditwheel can find the libs
 sudo ldconfig
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib64:/usr/lib:/usr/lib64
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/work/oneTBB-prefix/lib:/usr/lib:/usr/lib64
 
 SINGLE_WHEEL=0
 

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -81,7 +81,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
             -DITK_WRAP_double:BOOL=ON \
             -DITK_WRAP_complex_double:BOOL=ON \
             -DITK_WRAP_IMAGE_DIMS:STRING="2;3;4" \
-            -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -p)-linux-gnu \
+            -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -m)-linux-gnu \
             -DCMAKE_CXX_FLAGS:STRING="$compile_flags" \
             -DCMAKE_C_FLAGS:STRING="$compile_flags" \
             -DCMAKE_BUILD_TYPE:STRING="${build_type}" \
@@ -110,7 +110,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
           -DBUILD_TESTING:BOOL=OFF \
           -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
           -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
-          -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -p)-linux-gnu \
+          -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -m)-linux-gnu \
           -DCMAKE_CXX_FLAGS:STRING="$compile_flags" \
           -DCMAKE_C_FLAGS:STRING="$compile_flags" \
           -DCMAKE_BUILD_TYPE:STRING="${build_type}" \
@@ -168,12 +168,12 @@ done
 if test "${ARCH}" == "x64"; then
   sudo /opt/python/cp39-cp39/bin/pip3 install auditwheel wheel
   # This step will fixup the wheel switching from 'linux' to 'manylinux<version>' tag
-  for whl in dist/itk_*linux_$(uname -p).whl; do
+  for whl in dist/itk_*linux_$(uname -m).whl; do
       /opt/python/cp39-cp39/bin/auditwheel repair --plat manylinux${MANYLINUX_VERSION}_x86_64 ${whl} -w /work/dist/
       rm ${whl}
   done
 else
-  for whl in dist/itk_*$(uname -p).whl; do
+  for whl in dist/itk_*$(uname -m).whl; do
       auditwheel repair ${whl} -w /work/dist/
       rm ${whl}
   done


### PR DESCRIPTION
Motivation for this change is to build wheels with C++ ABI compatible with Slicer built using newer g++ having `_GLIBCXX_USE_CXX11_ABI` defaulting to `1`.

See https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

Note that the latest Slicer release (5.0) is built using centos7 based [^1] environment having `_GLIBCXX_USE_CXX11_ABI` set to `0`.

[^1]: https://github.com/Slicer/SlicerBuildEnvironment#supported-build-environments


We should likely build wheels using both `manylinux2014` and `manylinux_2_28`.

As of 2022.06.22, this pull-request uses `2_24`, as commented [^2] by @henryiii, I will instead update dockcross [^3] to add `2_28` based image (instead of `2_24)`.

[^2]: https://github.com/pypa/manylinux/issues/1332#issuecomment-1157666846
[^3]: https://github.com/dockcross/dockcross/pull/705

References:
* https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
* https://discuss.python.org/t/how-to-set-glibcxx-use-cxx11-abi-for-manylinux2014-and-manylinux2010-wheels/10551
* https://github.com/pytorch/pytorch/issues/51039
* https://github.com/pypa/manylinux/issues/1012
* https://github.com/dockcross/dockcross/pull/705