### PR TITLE
Remove clean step when building module wheels on Linux

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -101,7 +101,6 @@ for PYBIN in "${PYBINARIES[@]}"; do
       -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
       ${CMAKE_OPTIONS} \
     || exit 1
-    ${PYBIN}/python setup.py clean
 done
 
 if test "${ARCH}" == "x64"; then


### PR DESCRIPTION
This is required when chaining module builds. The latest module to be built
must know about all the headers of former modules.

Our use case is that CudaCommon generates an export header that is then required when building RTK. I guess this does not happen for [ITKUltrasound](https://github.com/KitwareMedical/ITKUltrasound/blob/v0.5.0/.github/workflows/build-test-package.yml#L170-L206) because all the modules it depends on are not generating export headers.

@dzenanz @thewtex Can you review this please?

@SimonRit FYI