### PR TITLE
manylinux: clean the build directory before building wheels

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -90,6 +90,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
       echo 'ITK source tree not available!' 1>&2
       exit 1
     fi
+    ${PYBIN}/python setup.py clean
     ${PYBIN}/python setup.py bdist_wheel --build-type Release -G Ninja -- \
       -DITK_DIR:PATH=${itk_build_dir} \
       -DITK_USE_SYSTEM_SWIG:BOOL=ON \


### PR DESCRIPTION
Commit #c953dc0 removed the clean step to allow accessing configured files when the script exists. However, when running two consecutive builds for different tarball specialization, the 1st build directory must be cleaned to make sure all libs are rebuilt for the right platform.