### PR TITLE
COMP: Define CMAKE_INSTALL_LIBDIR for mac arm remote module builds

### DIFF
--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -64,6 +64,7 @@ for VENV in "${VENVS[@]}"; do
     ${Python3_EXECUTABLE} setup.py bdist_wheel --build-type Release --plat-name ${plat_name} -G Ninja -- \
       -DCMAKE_MAKE_PROGRAM:FILEPATH=${NINJA_EXECUTABLE} \
       -DITK_DIR:PATH=${itk_build_path} \
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib \
       -DITK_USE_SYSTEM_SWIG:BOOL=ON \
       -DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel \
       -DSWIG_EXECUTABLE:FILEPATH=${itk_build_path}/Wrapping/Generators/SwigInterface/swig/bin/swig \


### PR DESCRIPTION
This was not defined on macos arm, causing packaging errors due to the wrong install path. Tested both on amd64 and arm.