### PR TITLE
BUG: Fix library install path on Windows and Linux

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -97,6 +97,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
       -DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel \
       -DSWIG_EXECUTABLE:FILEPATH=${itk_build_dir}/Wrapping/Generators/SwigInterface/swig/bin/swig \
       -DCMAKE_CXX_COMPILER_TARGET:STRING=$(uname -m)-linux-gnu \
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib \
       -DBUILD_TESTING:BOOL=OFF \
       -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
       -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \

--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -69,6 +69,7 @@ def build_wheels(py_envs=DEFAULT_PY_ENVS, cleanup=True, cmake_options=[]):
                 "-DWRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWheel",
                 "-DSWIG_EXECUTABLE:FILEPATH=%s/Wrapping/Generators/SwigInterface/swig/bin/swig.exe" % itk_build_path,
                 "-DBUILD_TESTING:BOOL=OFF",
+                "-DCMAKE_INSTALL_LIBDIR:STRING=lib",
                 "-DPython3_EXECUTABLE:FILEPATH=%s" % python_executable,
                 "-DPython3_INCLUDE_DIR:PATH=%s" % python_include_dir,
                 "-DPython3_INCLUDE_DIRS:PATH=%s" % python_include_dir,


### PR DESCRIPTION
Followup to 5b055e4c3fb3e23effd9fe213de3e7bf52fd4ec0 applying library install path fix on Windows and Linux platforms.

ITKSplitComponents external module Windows and Linux CI are passing with this patch applied at https://github.com/tbirdso/ITKSplitComponents/actions/runs/3175403084/jobs/5173400266.

Once this is merged I will amend module build scripts in existing `v5.3rc04.post3` archives and re-upload so that the patch can be applied in external module CI pipelines.