### PR TITLE
ENH: Allow for dash in Windows Python module

### DIFF
--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -96,7 +96,7 @@ def rename_wheel_init(py_env, filepath):
     module_version = w.version
 
     dist_dir = os.path.dirname(filepath)
-    wheel_dir = os.path.join(dist_dir, "itk_" + module_name + "-" + module_version)
+    wheel_dir = os.path.join(dist_dir, "itk_" + module_name.replace('-','_') + "-" + module_version)
     init_dir = os.path.join(wheel_dir, "itk")
     init_file = os.path.join(init_dir, "__init__.py")
 


### PR DESCRIPTION
The dash in the module name is automatically replaced by an underscore in the corresponding wheel file name.
This commit fixes the problem seen in https://github.com/SimonRit/RTK/actions/runs/3314648884/jobs/5474209928#step:6:2771. It was used to produce Windows [itk-rtk-cuda116 wheels](https://pypi.org/project/itk-rtk-cuda116/#files).