### PR TITLE
COMP: Ensure tbb library is built with the expected deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,15 @@ if(ITKPythonPackage_SUPERBUILD)
   endif()
 
   if(ITKPythonPackage_USE_TBB)
+
+    set(tbb_cmake_cache_args)
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+      list(APPEND tbb_cmake_cache_args
+        -DCMAKE_CXX_OSX_DEPLOYMENT_TARGET_FLAG:STRING="-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}"
+        -DCMAKE_C_OSX_DEPLOYMENT_TARGET_FLAG:STRING="-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}"
+        )
+    endif()
+
     ExternalProject_add(oneTBB
       URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.3.0.tar.gz
       URL_HASH SHA256=8f616561603695bbb83871875d2c6051ea28f8187dbe59299961369904d1d49e
@@ -114,6 +123,7 @@ if(ITKPythonPackage_SUPERBUILD)
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/../oneTBB-prefix
         -DCMAKE_INSTALL_LIBDIR:STRING=lib # Skip default initialization by GNUInstallDirs CMake module
         ${ep_common_cmake_cache_args}
+        ${tbb_cmake_cache_args}
         -DCMAKE_BUILD_TYPE:STRING=Release
       BUILD_BYPRODUCTS "${TBB_DIR}/TBBConfig.cmake"
       USES_TERMINAL_DOWNLOAD 1

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -50,11 +50,18 @@ DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
 DELOCATE_WHEEL=${VENV}/bin/delocate-wheel
 DELOCATE_PATCH=${VENV}/bin/delocate-patch
 
+build_type="Release"
+
 if [[ $(arch) == "arm64" ]]; then
+  osx_target="11.0"
+  osx_arch="arm64"
   use_tbb="OFF"
 else
+  osx_target="10.9"
+  osx_arch="x86_64"
   use_tbb="ON"
 fi
+
 # Build standalone project and populate archive cache
 tbb_dir=$PWD/oneTBB-prefix/lib/cmake/TBB
 # So delocate can find the libs
@@ -64,7 +71,10 @@ pushd ITK-source > /dev/null 2>&1
   ${CMAKE_EXECUTABLE} -DITKPythonPackage_BUILD_PYTHON:PATH=0 \
     -DITKPythonPackage_USE_TBB:BOOL=${use_tbb} \
     -G Ninja \
+    -DCMAKE_BUILD_TYPE:STRING=${build_type} \
     -DCMAKE_MAKE_PROGRAM:FILEPATH=${NINJA_EXECUTABLE} \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${osx_target} \
+    -DCMAKE_OSX_ARCHITECTURES:STRING=${osx_arch} \
       ${SCRIPT_DIR}/../
   ${NINJA_EXECUTABLE}
 popd > /dev/null 2>&1
@@ -83,16 +93,11 @@ for VENV in "${VENVS[@]}"; do
 
     ${Python3_EXECUTABLE} -m pip install --upgrade -r ${SCRIPT_DIR}/../requirements-dev.txt
 
-    build_type="Release"
     if [[ $(arch) == "arm64" ]]; then
       plat_name="macosx-11.0-arm64"
-      osx_target="11.0"
-      osx_arch="arm64"
       build_path="${SCRIPT_DIR}/../ITK-${py_mm}-macosx_arm64"
     else
       plat_name="macosx-10.9-x86_64"
-      osx_target="10.9"
-      osx_arch="x86_64"
       build_path="${SCRIPT_DIR}/../ITK-${py_mm}-macosx_x86_64"
     fi
     if [[ ! -z "${MACOSX_DEPLOYMENT_TARGET}" ]]; then


### PR DESCRIPTION
This commit is a follow-up of these commits:
* a5f774ba5 (ENH: Add TBB support to Linux wheels)
* 374c744a1 (ENH: Add macOS wheel TBB support)
* 037a326c1 (ENH: Build macOS module wheels with TBB support)

It ensures that oneTBB is built specifying the non-default options expected by oneTBB [^1] and it should ensure the library can be loaded on macOS >= 10.9.

[^1]: https://github.com/oneapi-src/oneTBB/blob/v2021.3.0/CMakeLists.txt#L32-L39

See https://discourse.itk.org/t/itk-5-3rc4-post3-failure-to-load-libtbb-library-observed-on-macos-10-13/5405/1#suggested-path-forward-3