### PR TITLE
BUG: Fix Linux Python 3.11 pattern matching

### DIFF
--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -12,7 +12,7 @@ if [[ $# -eq 0 ]]; then
   PYBIN=(/opt/python/*/bin)
   PYBINARIES=()
   for version in "${PYBIN[@]}"; do
-    if [[ ${version} == *"cp37"* || ${version} == *"cp38"* || ${version} == *"cp39"* || ${version} == *"cp310"* || ${version} == *"cp311" ]]; then
+    if [[ ${version} == *"cp37"* || ${version} == *"cp38"* || ${version} == *"cp39"* || ${version} == *"cp310"* || ${version} == *"cp311"* ]]; then
       PYBINARIES+=(${version})
     fi
   done


### PR DESCRIPTION
Addresses issue where Python 3.11 is not found when building ITK wheels for all Python versions (without "cp<version>" arguments).

Successfully rebuilt `-manylinux2014` Python 3.11 wheels, rebuilding `-manylinux_2_28` wheels on `blaster` now.