### PR TITLE
ENH: Use minimum system zstd in Linux scripts

### DIFF
--- a/scripts/dockcross-manylinux-build-tarball.sh
+++ b/scripts/dockcross-manylinux-build-tarball.sh
@@ -7,10 +7,37 @@
 if test -d /home/kitware/Packaging; then
   cd /home/kitware/Packaging
 fi
-zstd_exe=zstd
-if test -e /home/kitware/Support/zstd-build/programs/zstd; then
+
+# -----------------------------------------------------------------------
+
+zstd_exe=`(which zstd)`
+if [[ -z ${zstd_exe} && -e /home/kitware/Support/zstd-build/programs/zstd ]]; then
   zstd_exe=/home/kitware/Support/zstd-build/programs/zstd
 fi
+
+# Find an appropriately versioned zstd.
+#
+# "--long" is introduced in zstd==v1.3.2
+# https://github.com/facebook/zstd/releases/tag/v1.3.2
+#
+# Sample --version output:
+# *** zstd command line interface 64-bits v1.4.4, by Yann Collet *** #
+ZSTD_MIN_VERSION="1.3.2"
+
+if [[ -n `(which dpkg)` && `(${zstd_exe} --version)` =~ v([0-9]+.[0-9]+.[0-9]+) ]]; then
+  if $(dpkg --compare-versions ${BASH_REMATCH[1]} "ge" ${ZSTD_MIN_VERSION} ); then
+    echo "Found zstd v${BASH_REMATCH[1]} at ${zstd_exe}"
+  else
+    echo "Expected zstd v${ZSTD_MIN_VERSION} or higher but found v${BASH_REMATCH[1]} at ${zstd_exe}"
+    exit 255
+  fi
+else
+  # dpkg not available for version comparison so simply print version
+  ${zstd_exe} --version
+fi
+
+# -----------------------------------------------------------------------
+
 tar -c --to-stdout \
   ITKPythonPackage/ITK-* \
   ITKPythonPackage/oneTBB* \
@@ -18,5 +45,6 @@ tar -c --to-stdout \
 $zstd_exe -f \
   -10 \
   -T6 \
+  --long=31 \
   ./ITKPythonBuilds-linux.tar \
   -o ./ITKPythonBuilds-linux.tar.zst

--- a/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh
@@ -35,16 +35,16 @@ do
 done
 # -----------------------------------------------------------------------
 
-# Packages distributed by github are in zstd format, so we need to download that binary to uncompress
-if [[ ! -f zstd-1.2.0-linux.tar.gz ]]; then
-  curl https://data.kitware.com/api/v1/file/592dd8068d777f16d01e1a92/download -o zstd-1.2.0-linux.tar.gz
-  gunzip -d zstd-1.2.0-linux.tar.gz
-  tar xf zstd-1.2.0-linux.tar
-fi
-if [[ ! -f ./zstd-1.2.0-linux/bin/unzstd ]]; then
-  echo "ERROR: can not find required binary './zstd-1.2.0-linux/bin/unzstd'"
+# Verifies that unzstd binary is available to decompress ITK build archives.
+unzstd_exe=`(which unzstd)`
+
+if [[ -z ${unzstd_exe} ]]; then
+  echo "ERROR: can not find required binary 'unzstd' "
   exit 255
 fi
+
+# Expect unzstd > v1.3.2, see discussion in `dockcross-manylinux-build-tarball.sh`
+${unzstd_exe} --version
 
 TARBALL_NAME="ITKPythonBuilds-linux${TARBALL_SPECIALIZATION}.tar"
 
@@ -55,7 +55,7 @@ if [[ ! -f ./${TARBALL_NAME}.zst ]]; then
   echo "ERROR: can not find required binary './${TARBALL_NAME}.zst'"
   exit 255
 fi
-./zstd-1.2.0-linux/bin/unzstd ./${TARBALL_NAME}.zst -o ${TARBALL_NAME}
+${unzstd_exe} --long=31 ./${TARBALL_NAME}.zst -o ${TARBALL_NAME}
 if [ "$#" -lt 1 ]; then
   echo "Extracting all files";
   tar xf ${TARBALL_NAME}


### PR DESCRIPTION
Changes:
- Add `--long=31` option for improved Linux build archive compression
- Verify that zstd is at least v1.3.2 where `--long` is introduced
- Remove zstd v1.2.0 download option

Required for v5.3rc04.post4 builds which add Python 3.11 archives. Without the `--long=31` option these archives are over the 2GB limit imposed by Github. With the `--long=31` option build archives are right at the threshold at about 1.97GB. https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/tag/v5.3rc04.post4

I have updated zstd on `blaster` via `sudo apt install zstd` such that the installed zstd/unzstd version is now v1.4.4. This PR introduces the requirement that `unzstd>1.3.2` is used to decompress archives for building module wheels on Linux.

Echoes compression options introduced in https://github.com/InsightSoftwareConsortium/ITKPythonPackage/commit/de54e148584827cc3cb89898358510877762f1b7 that were reverted due to zstd compatibility on Linux at the time.

I have tested by
1. Running `dockcross-manylinux-build-tarball.sh` to build archives on `blaster`;
2. Running `dockcross-manylinux-download-cache-and-build-module-wheels.sh` to build ITKSplitComponents module wheels in CI: https://github.com/InsightSoftwareConsortium/ITKSplitComponents/actions/runs/3490135651/jobs/5841170399