### PR TITLE
BUG: Bump skbuild to 0.16.2 to resolve Windows build failures

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-scikit-build==0.8.1
+scikit-build==0.16.2

--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -49,7 +49,7 @@ def build_wheels(py_envs=DEFAULT_PY_ENVS, cleanup=True, cmake_options=[]):
             if os.path.exists(requirements_file):
                 check_call([pip, "install", "--upgrade", "-r", requirements_file])
             check_call([pip, "install", "cmake"])
-            check_call([pip, "install", "scikit_build"])
+            check_call([pip, "install", "scikit_build", "--upgrade"])
             check_call([pip, "install", "ninja"])
             check_call([pip, "install", "delvewheel"])
 


### PR DESCRIPTION
Addresses ITK module issue detailed in https://github.com/scikit-build/scikit-build/issues/805

Will validate with experimental ITKRemoteModuleBuildPackageAction/ITKSplitComponents CI prior to merge