### PR TITLE
COMP: Remove terminal flags for CI builds of Linux ARM module wheels

### DIFF
--- a/scripts/manylinux_2_28_aarch64-build-module-wheels.sh
+++ b/scripts/manylinux_2_28_aarch64-build-module-wheels.sh
@@ -35,4 +35,4 @@ if [[ -n ${LD_LIBRARY_PATH} ]]; then
 fi
 
 docker run --privileged --rm tonistiigi/binfmt --install all
-docker run --rm -it $DOCKER_ARGS -v $(pwd):/work/ quay.io/pypa/manylinux${MANYLINUX_VERSION}_aarch64:${IMAGE_TAG} "/ITKPythonPackage/scripts/internal/manylinux-aarch64-build-module-wheels.sh" "$@"
+docker run --rm $DOCKER_ARGS -v $(pwd):/work/ quay.io/pypa/manylinux${MANYLINUX_VERSION}_aarch64:${IMAGE_TAG} "/ITKPythonPackage/scripts/internal/manylinux-aarch64-build-module-wheels.sh" "$@"


### PR DESCRIPTION
These are not needed for non-interactive execution and causes failure in CI:

```
  the input device is not a TTY
```

Testing can continue following #233 