### PR TITLE
ENH: Update manylinux images to latest tagged version 20221201-fd49c08

### DIFF
--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -28,7 +28,7 @@
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221108-102ebcc}
+IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -19,7 +19,7 @@
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221108-102ebcc}
+IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64


### PR DESCRIPTION
This fixes the sudo error, and has NASM inside. In [zarrIO](https://github.com/dzenanz/ITKIOOMEZarrNGFF/actions/runs/3596251270/jobs/6056706899) module, it goes over NASM error which was appearing around build step 500, just to run into another error around build step 800.