### PR TITLE
ENH: Bump manylinux image tag

### DIFF
--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -23,12 +23,12 @@
 # For example,
 #
 #   export MANYLINUX_VERSION=2014
-#   export IMAGE_TAG=20221108-102ebcc
+#   export IMAGE_TAG=20221205-459c9f0
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
+IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -14,12 +14,12 @@
 # For example,
 #
 #   export MANYLINUX_VERSION=2014
-#   export IMAGE_TAG=20221108-102ebcc
+#   export IMAGE_TAG=20221205-459c9f0
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
+IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh
@@ -99,6 +99,7 @@ if [[ -n ${ITKPYTHONPACKAGE_TAG} ]]; then
   
   rm -rf ITKPythonPackage/scripts/
   cp -r IPP-tmp/scripts ITKPythonPackage/
+  cp IPP-tmp/requirements-dev.txt ITKPythonPackage/
   rm -rf IPP-tmp/
 fi
 

--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -84,6 +84,8 @@ for PYBIN in "${PYBINARIES[@]}"; do
 
     if [[ -e /work/requirements-dev.txt ]]; then
       ${PYBIN}/pip install --upgrade -r /work/requirements-dev.txt
+    elif [[ -e /ITKPythonPackage/requirements-dev.txt ]]; then
+      ${PYBIN}/pip install --upgrade -r /ITKPythonPackage/requirements-dev.txt
     fi
     version=$(basename $(dirname ${PYBIN}))
     # Remove "m" -- not present in Python 3.8 and later


### PR DESCRIPTION
Includes downgrade back from `gcc-toolset-12` to `gcc-toolset-11` tools for compatibility with ITK v5.3.0 tarballs.

See discussion in https://github.com/InsightSoftwareConsortium/ITK/issues/3785