### PR TITLE
BUG: Revert to valid `manylinux2014-x64` image tag

### DIFF
--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -28,7 +28,15 @@
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
+
+if [[ ${MANYLINUX_VERSION} == _2_28 ]]; then
+  IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
+elif [[ ${MANYLINUX_VERSION} == 2014 ]]; then
+  IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
+else
+  echo "Unknown manylinux version ${MANYLINUX_VERSION}"
+  exit 1;
+fi
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -19,7 +19,15 @@
 #
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
+
+if [[ ${MANYLINUX_VERSION} == _2_28 ]]; then
+  IMAGE_TAG=${IMAGE_TAG:=20221205-459c9f0}
+elif [[ ${MANYLINUX_VERSION} == 2014 ]]; then
+  IMAGE_TAG=${IMAGE_TAG:=20221201-fd49c08}
+else
+  echo "Unknown manylinux version ${MANYLINUX_VERSION}"
+  exit 1;
+fi
 
 # Generate dockcross scripts
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64


### PR DESCRIPTION
While `manylinux_2_28` and `manylinux2014` images are typically tagged together, a recent `manylinux_2_28` release addressing a _2_28 toolset compatibility issue was not paired with a `manylinux2014` release. This commit updates Linux build scripts to decouple the tag used for each image.

See also: https://hub.docker.com/u/dockcross