### PR TITLE
Pass option to setup.py and cmake on Windows, clean-up and avoid unnecessary downloads

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -44,7 +44,9 @@ brew upgrade cmake
 
 # Fetch ITKPythonBuilds archive containing ITK build artifacts
 echo "Fetching https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3.0}/ITKPythonBuilds-macosx.tar.zst"
-aria2c -c --file-allocation=none -o ITKPythonBuilds-macosx.tar.zst -s 10 -x 10 https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3.0}/ITKPythonBuilds-macosx.tar.zst
+if [[ ! -f ITKPythonBuilds-macosx.tar.zst ]]; then
+  aria2c -c --file-allocation=none -o ITKPythonBuilds-macosx.tar.zst -s 10 -x 10 https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3.0}/ITKPythonBuilds-macosx.tar.zst
+fi
 unzstd --long=31 ITKPythonBuilds-macosx.tar.zst -o ITKPythonBuilds-macosx.tar
 PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
 tar xf ITKPythonBuilds-macosx.tar --checkpoint=10000 --checkpoint-action=dot

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -11,6 +11,14 @@
 #
 #     > windows-download-cache-and-build-module-wheels.ps1 11
 #
+# - other parameters are passed to setup.py. If one of the parameters is "--",
+#   the following parameters will be passed to cmake.
+#     For instance, for Python 3.11, excluding nvcuda.dll during packaging
+#     and setting RTK_USE_CUDA ON during configuration:
+#
+#     > windows-download-cache-and-build-module-wheels.ps1 11 --exclude-libs nvcuda.dll "--" -DRTK_USE_CUDA:BOOL=ON
+#
+#
 # -----------------------------------------------------------------------
 # Environment variables used in this script:
 #
@@ -71,7 +79,14 @@ $env:Path += ";C:\P\grep"
 
 # Build ITK module dependencies, if any
 $build_command = "& `"C:\Python$pythonVersion-x$pythonArch\python.exe`" `"C:\P\IPP\scripts\windows_build_module_wheels.py`" --no-cleanup --py-envs `"3$($args[0])-x64`""
-echo "Build command: $build_command"
+foreach ($arg in $args[1..$args.length]) {
+  if ($arg.substring(0,2) -eq "--") {
+    $build_command = "$build_command $($arg)"
+  }
+  else {
+    $build_command = "$build_command `"$($arg)`""
+  }
+}
 
 echo "ITK_MODULE_PREQ: $env:ITK_MODULE_PREQ $ITK_MODULE_PREQ"
 if ($env:ITK_MODULE_PREQ) {

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -46,6 +46,9 @@ iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.co
 if (-not $env:ITK_PACKAGE_VERSION) { $env:ITK_PACKAGE_VERSION = 'v5.3.0' }
 echo "Fetching build archive $env:ITK_PACKAGE_VERSION"
 Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/$env:ITK_PACKAGE_VERSION/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
+if (Test-Path C:\P) {
+  Remove-Item -Recurse -Force C:\P
+}
 7z x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 
 # Optional: Update ITKPythonPackage build scripts

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -45,9 +45,11 @@ iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.co
 
 if (-not $env:ITK_PACKAGE_VERSION) { $env:ITK_PACKAGE_VERSION = 'v5.3.0' }
 echo "Fetching build archive $env:ITK_PACKAGE_VERSION"
-Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/$env:ITK_PACKAGE_VERSION/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
 if (Test-Path C:\P) {
   Remove-Item -Recurse -Force C:\P
+}
+if (-not (Test-Path ITKPythonBuilds-windows.zip)) {
+  Invoke-WebRequest -Uri "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/$env:ITK_PACKAGE_VERSION/ITKPythonBuilds-windows.zip" -OutFile "ITKPythonBuilds-windows.zip"
 }
 7z x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 
@@ -74,9 +76,13 @@ if ($env:ITKPYTHONPACKAGE_TAG) {
 }
 
 # Get other build dependencies
-Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -OutFile "doxygen-1.8.11.windows.bin.zip"
+if (-not (Test-Path doxygen-1.8.11.windows.bin.zip)) {
+  Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -OutFile "doxygen-1.8.11.windows.bin.zip"
+}
 7z x doxygen-1.8.11.windows.bin.zip -oC:\P\doxygen -aoa -r
-Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -OutFile "grep-win.zip"
+if (-not (Test-Path grep-win.zip)) {
+  Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -OutFile "grep-win.zip"
+}
 7z x grep-win.zip -oC:\P\grep -aoa -r
 $env:Path += ";C:\P\grep"
 


### PR DESCRIPTION
These 3 commits are used to allow (and improve) RTK compilation with CUDA following the latest developments of ITKRemoteModuleBuildTestPackageAction, see RTKConsortium/RTK#526. I haven't worked on specific options for each itk-module-deps (yet, I'm not sure it will be required for RTKConsortium/RTK#492)...