### PR TITLE
ENH: Build manylinux2014 wheels by default

### DIFF
--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -18,15 +18,15 @@
 # These variables are set with the `export` bash command before calling the script.# 
 # For example,
 #
-#   export MANYLINUX_VERSION="_2_28"
+#   export MANYLINUX_VERSION="2014"
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 # 
 # `LD_LIBRARY_PATH`: Shared libraries to be included in the resulting wheel.
 #   For instance, `export LD_LIBRARY_PATH="/path/to/OpenCL.so:/path/to/OpenCL.so.1.2"`
 #
-# `MANYLINUX_VERSION`: Specialized manylinux image to use for building. Default is _2_28.
+# `MANYLINUX_VERSION`: Specialized manylinux image to use for building. Default is 2014.
 #   See https://github.com/dockcross/dockcross for available versions and tags.
-#   For instance, `export MANYLINUX_VERSION=2014`
+#   For instance, `export MANYLINUX_VERSION=_2_28`
 #
 # `TARGET_ARCH`: Target architecture for which wheels should be built.
 #   For instance, `export MANYLINUX_VERSION=aarch64`

--- a/scripts/dockcross-manylinux-build-wheels.sh
+++ b/scripts/dockcross-manylinux-build-wheels.sh
@@ -18,7 +18,7 @@
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 #
 
-MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
+MANYLINUX_VERSION=${MANYLINUX_VERSION:=2014}
 
 if [[ ${MANYLINUX_VERSION} == _2_28 ]]; then
   IMAGE_TAG=${IMAGE_TAG:=20230106-1aeaea0}

--- a/scripts/dockcross-manylinux-download-cache.sh
+++ b/scripts/dockcross-manylinux-download-cache.sh
@@ -74,7 +74,7 @@ ${unzstd_exe} --version
 # -----------------------------------------------------------------------
 # Fetch build archive
 
-MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
+MANYLINUX_VERSION=${MANYLINUX_VERSION:=2014}
 TARGET_ARCH=${TARGET_ARCH:=x64}
 
 case ${TARGET_ARCH} in

--- a/scripts/dockcross-manylinux-set-vars.sh
+++ b/scripts/dockcross-manylinux-set-vars.sh
@@ -30,9 +30,9 @@ ITKPYTHONPACKAGE_TAG=${ITKPYTHONPACKAGE_TAG:=master}
 ########################################################################
 # Docker image parameters
 
-# Specialized manylinux image to use for building. Default is _2_28.
+# Specialized manylinux image to use for building. Default is 2014.
 #   See https://github.com/dockcross/dockcross for available versions and tags.
-MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
+MANYLINUX_VERSION=${MANYLINUX_VERSION:=2014}
 
 # Target platform architecture (x64, aarch64)
 TARGET_ARCH=${TARGET_ARCH:=x64}

--- a/scripts/internal/manylinux-build-common.sh
+++ b/scripts/internal/manylinux-build-common.sh
@@ -80,6 +80,6 @@ if ! type ninja > /dev/null 2>&1; then
   popd
 fi
 
-MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
+MANYLINUX_VERSION=${MANYLINUX_VERSION:=2014}
 
 echo "Building wheels for $ARCH using manylinux${MANYLINUX_VERSION}"


### PR DESCRIPTION
Updates default manylinux cross-compilation image from "_2_28" to "2014" which corresponds to toolset downgrade from glibc 2.28+ (Ubuntu 20.04+) to glibc 2.17+ (Ubuntu 18.04+).

This downgrade is made to better address existing community needs. Both "_2_28" and "2014" builds continue to be available and supported.

EDIT: Pending investigation of aarch64 failure in https://github.com/tbirdso/ITKSplitComponents/actions/runs/4284448724/jobs/7461422239