### PR TITLE
Deps with args

### DIFF
--- a/scripts/dockcross-manylinux-build-module-deps.sh
+++ b/scripts/dockcross-manylinux-build-module-deps.sh
@@ -69,7 +69,7 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
   fi
 
   echo "Building module dependency ${MODULE_NAME}"
-  ./dockcross-manylinux-download-cache-and-build-module-wheels.sh $@
+  ./dockcross-manylinux-download-cache-and-build-module-wheels.sh "$@"
   popd
 
   echo "Cleaning up module dependency"

--- a/scripts/dockcross-manylinux-build-module-deps.sh
+++ b/scripts/dockcross-manylinux-build-module-deps.sh
@@ -74,6 +74,7 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
 
   echo "Cleaning up module dependency"
   cp ./${MODULE_NAME}/include/* include/
+  find ${MODULE_NAME}/_skbuild -type f -wholename "**/cmake-build/include/*" -print -exec cp {} include \;
 
   # Cache build archive
   if [[ `(compgen -G ./ITKPythonBuilds-linux*.tar.zst)` ]]; then


### PR DESCRIPTION
First commit is required when there are spaces in some options of `dockcross-manylinux-download-cache-and-build-module-wheels.sh` (e.g. [here](https://github.com/RTKConsortium/RTK/blob/master/.github/workflows/build-test-package-python-cuda.yml#L6)).

Second  commit is required when the dependencies use generated include files (e.g. the `ModuleExport.h`).

These two changes where required to build RTK with external CudaCommon module. See first failure due to problem with options [here](https://github.com/RTKConsortium/RTK/actions/runs/4378694689/jobs/7663759417#step:4:31), second failure due to missing CudaCommonExport.h [here](https://github.com/RTKConsortium/RTK/actions/runs/4403309018/jobs/7711496893#step:4:1970) and [successful compilation](https://github.com/RTKConsortium/RTK/actions/runs/4406673185/jobs/7719246805) 