### PR TITLE
Fix macOS itk wheel size explicitly removing _skbuild directory

### DIFF
--- a/scripts/macpython-build-common.sh
+++ b/scripts/macpython-build-common.sh
@@ -70,6 +70,10 @@ for PYBIN in "${PYBINARIES[@]}"; do
 done
 
 # -----------------------------------------------------------------------
+SKBUILD_DIR=_skbuild
+
+
+# -----------------------------------------------------------------------
 # Ensure that requirements are met
 brew update
 brew info doxygen | grep --quiet 'Not installed' && brew install doxygen

--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -52,6 +52,7 @@ fi
 # * PYTHON_VERSIONS
 # * NINJA_EXECUTABLE
 # * SCRIPT_DIR
+# * SKBUILD_DIR
 # * VENVS=()
 
 MACPYTHON_PY_PREFIX=""
@@ -113,7 +114,7 @@ for VENV in "${VENVS[@]}"; do
       -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
       ${CMAKE_OPTIONS} \
     || exit 1
-    # ${Python3_EXECUTABLE} setup.py clean    # Permission denied
+    # rm -r ${SKBUILD_DIR} # Permission denied
 done
 
 for wheel in $PWD/dist/*.whl; do

--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -45,8 +45,16 @@ fi
 # -----------------------------------------------------------------------
 # These variables are set in common script:
 #
+# * CMAKE_EXECUTABLE
+# * CMAKE_OPTIONS
+# * MACPYTHON_PY_PREFIX
+# * PYBINARIES
+# * PYTHON_VERSIONS
+# * NINJA_EXECUTABLE
+# * SCRIPT_DIR
+# * VENVS=()
+
 MACPYTHON_PY_PREFIX=""
-# PYBINARIES="" # unused
 SCRIPT_DIR=""
 VENVS=()
 

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -26,6 +26,7 @@
 # * PYTHON_VERSIONS
 # * NINJA_EXECUTABLE
 # * SCRIPT_DIR
+# * SKBUILD_DIR
 # * VENVS=()
 
 MACPYTHON_PY_PREFIX=""
@@ -145,7 +146,7 @@ for VENV in "${VENVS[@]}"; do
         -DITK_WRAP_DOC:BOOL=ON \
         ${CMAKE_OPTIONS}
       # Cleanup
-      ${Python3_EXECUTABLE} setup.py clean
+      rm -r ${SKBUILD_DIR}
 
     else
 
@@ -208,7 +209,7 @@ for VENV in "${VENVS[@]}"; do
           ${CMAKE_OPTIONS} \
         || exit 1
         # Cleanup
-        ${Python3_EXECUTABLE} setup.py clean
+        rm -r ${SKBUILD_DIR}
       done
 
     fi

--- a/scripts/macpython-build-wheels.sh
+++ b/scripts/macpython-build-wheels.sh
@@ -19,6 +19,15 @@
 # -----------------------------------------------------------------------
 # These variables are set in common script:
 #
+# * CMAKE_EXECUTABLE
+# * CMAKE_OPTIONS
+# * MACPYTHON_PY_PREFIX
+# * PYBINARIES
+# * PYTHON_VERSIONS
+# * NINJA_EXECUTABLE
+# * SCRIPT_DIR
+# * VENVS=()
+
 MACPYTHON_PY_PREFIX=""
 PYBINARIES=""
 SCRIPT_DIR=""


### PR DESCRIPTION
This commit works around an issue with the "clean" command (see [1]) that was not properly considering the current MACOSX_DEPLOYMENT_TARGET env. variable.

It does by explicitly deleting the scikit-build directory without relying on the "setup.py clean" command not respecting the selected deployment target.

Considering that

1. the libraries installed while building the dependent itk-* wheels were accumulated in the install directory (e.g `_skbuild/macosx-X.Y-<arch>-3.9/setuptools/lib`)

2. the wheel is generated by systematically archiving the content of the install directory. The manifest files are used to select which file to "copy" into the install directory but these are not used by the function creating the wheel archive. See [2]

3. following https://github.com/scikit-build/scikit-build/commit/ac9648bf4 (post 0.8.1), the platform name was properly considered on macOS *only* when building the wheel (using "setup.py build") but not when cleaning the build directory (using "setup.py clean")

... all the wheels depending on "itk-core" where unexpectedly large because there are including the cumulative set of files from all the wheels built beforehand.

[1] https://github.com/scikit-build/scikit-build/issues/1012
[2] https://github.com/pypa/wheel/blob/0.40.0/src/wheel/wheelfile.py#L121-L141