### PR TITLE
Fix libraries in linux module wheels

### DIFF
--- a/scripts/dockcross-manylinux-build-module-wheels.sh
+++ b/scripts/dockcross-manylinux-build-module-wheels.sh
@@ -61,12 +61,18 @@ chmod 777 $(pwd)/tools
 mkdir -p dist
 DOCKER_ARGS="-v $(pwd)/dist:/work/dist/ -v ${script_dir}/..:/ITKPythonPackage -v $(pwd)/tools:/tools"
 DOCKER_ARGS+=" -e MANYLINUX_VERSION"
+DOCKER_ARGS+=" -e LD_LIBRARY_PATH"
 # Mount any shared libraries
 if [[ -n ${LD_LIBRARY_PATH} ]]; then
   for libpath in ${LD_LIBRARY_PATH//:/ }; do
-	  DOCKER_ARGS+=" -v ${libpath}:/usr/lib64/$(basename -- ${libpath})"
+          DOCKER_LIBRARY_PATH="/usr/lib64/$(basename -- ${libpath})"
+	  DOCKER_ARGS+=" -v ${libpath}:${DOCKER_LIBRARY_PATH}"
+          if test -d ${libpath}; then
+              DOCKER_LD_LIBRARY_PATH+="${DOCKER_LIBRARY_PATH}:${DOCKER_LD_LIBRARY_PATH}"
+          fi
   done
 fi
+export LD_LIBRARY_PATH="${DOCKER_LD_LIBRARY_PATH}"
 
 if [[ "${TARGET_ARCH}" = "aarch64" ]]; then
   echo "Install aarch64 architecture emulation tools to perform build for ARM platform"

--- a/scripts/internal/auditwheel_whitelist_monkeypatch.py
+++ b/scripts/internal/auditwheel_whitelist_monkeypatch.py
@@ -5,13 +5,13 @@ import argparse
 import sys
 
 from auditwheel.main import main
-from auditwheel.policy import _POLICIES as POLICIES
+from auditwheel.policy import WheelPolicies
 
 
 def exclude_libs(whitelist):
     # Do not include the following libraries when repairing wheels.
     for lib in whitelist.split(';'):
-        for p in POLICIES:
+        for p in WheelPolicies().policies:
             p['lib_whitelist'].append(lib)
 
 if __name__ == "__main__":


### PR DESCRIPTION
The goal is to fix #263. The second commit inform auditwheel on where are the wheels libraries. However, it does not seem to work so far, see the wheels produced by https://github.com/RTKConsortium/ITKCudaCommon/actions/runs/7901454685 which contain renamed versions of libcuda.so and libcudart.so, e.g.:
```
srit@srit-Precision-5480:~/tmp$ unzip LinuxWheel310-cuda116.zip 
Archive:  LinuxWheel310-cuda116.zip
  inflating: itk_cudacommon_cuda116-1.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl  
  inflating: itk_cudacommon_cuda116-1.0.1-cp310-cp310-manylinux_2_28_x86_64.whl  
srit@srit-Precision-5480:~/tmp$ unzip ../itk_cudacommon_cuda116-1.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl  
Archive:  ../itk_cudacommon_cuda116-1.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   creating: itk/
   creating: itk_cudacommon_cuda116-1.0.1.dist-info/
   creating: itk_cudacommon_cuda116.libs/
   creating: itk/Configuration/
  inflating: itk/CudaCommonPython.py  
  inflating: itk/_CudaCommonPython.so  
  inflating: itk/itkCudaDataManagerPython.py  
  inflating: itk/itkCudaImageDataManagerPython.py  
  inflating: itk/itkCudaImagePython.py  
  inflating: itk/itkImageSourceCudaCommonPython.py  
  inflating: itk/itkImageToImageFilterCudaCommonPython.py  
  inflating: itk/Configuration/CudaCommonConfig.py  
  inflating: itk/Configuration/CudaCommon_snake_case.py  
  inflating: itk_cudacommon_cuda116-1.0.1.dist-info/LICENSE  
  inflating: itk_cudacommon_cuda116-1.0.1.dist-info/METADATA  
  inflating: itk_cudacommon_cuda116-1.0.1.dist-info/WHEEL  
  inflating: itk_cudacommon_cuda116-1.0.1.dist-info/top_level.txt  
  inflating: itk_cudacommon_cuda116-1.0.1.dist-info/RECORD  
  inflating: itk_cudacommon_cuda116.libs/libcudart-45da57e3.so.11.6.55  
  inflating: itk_cudacommon_cuda116.libs/libtbb-b694c9f9.so.12.9  
  inflating: itk_cudacommon_cuda116.libs/libcuda-b083b9ef.so.1  
```
 I'll keep trying but maybe the whitelist strategy in auditwheel does not work anymore? Or I missed something? cc @LucasGandel 