### PR TITLE
BUG: Remove extra 7zip compression flags

### DIFF
--- a/scripts/windows-build-tarball.ps1
+++ b/scripts/windows-build-tarball.ps1
@@ -4,4 +4,5 @@
 
 cd C:\P\
 Remove-Item IPP\dist\*
-C:\7-Zip\7z.exe a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 -r 'C:\P\ITKPythonBuilds-windows.zip' -w 'C:\P\IPP' 
+C:\7-Zip\7z.exe a -t7z -r 'C:\P\ITKPythonBuilds-windows.zip' -w 'C:\P\IPP' 
+# C:\7-Zip\7z.exe a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 -r 'C:\P\ITKPythonBuilds-windows.zip' -w 'C:\P\IPP' 


### PR DESCRIPTION
Crashing with the current version of 7zip:

```
$ powershell "IPP/scripts/windows-build-tarball.ps1"

7-Zip 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20

Scanning the drive:
10059 folders, 152678 files, 9885141124 bytes (9428 MiB)

Creating archive: C:\P\ITKPythonBuilds-windows.zip

Add new data to archive: 10059 folders, 152678 files, 9885141124 bytes (9428 MiB)

System ERROR:
Internal Error: The failure in hardware (RAM or CPU), OS or program
```

The archive is small enough with recent improvements.