### PR TITLE
COMP: Updates for linux aarch64 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,8 @@ if(ITKPythonPackage_SUPERBUILD)
 
   set(ITK_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
 
-  # release branch, 2024-04-08
-  set(ITK_GIT_TAG "v5.4rc03")
+  # master branch, 2024-04-12
+  set(ITK_GIT_TAG "81be125a547ba2fa2343ae36cce8812bd711c5b4")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download ITK, so that it can reused

--- a/scripts/internal/manylinux-aarch64-build-module-wheels.sh
+++ b/scripts/internal/manylinux-aarch64-build-module-wheels.sh
@@ -2,6 +2,10 @@
 
 # Run this script inside a dockcross container to build Python wheels for an aarch ITK module.
 cd /work
+# Update GPG keys
+dnf upgrade -y almalinux-release
+# Newer Python.cmake module required for SABI
+pipx upgrade cmake
 yum -y install sudo ninja-build
 /opt/python/cp39-cp39/bin/python -m pip install -r /ITKPythonPackage/requirements-dev.txt
 for PYBIN in "${PYBINARIES[@]}"; do

--- a/scripts/internal/manylinux-build-wheels.sh
+++ b/scripts/internal/manylinux-build-wheels.sh
@@ -181,13 +181,13 @@ if test "${ARCH}" == "x64"; then
 else
   for whl in dist/itk_*$(uname -m).whl; do
       auditwheel repair ${whl} -w /work/dist/
-      rm ${whl}
   done
 fi
 
 # Install packages and test
 for PYBIN in "${PYBINARIES[@]}"; do
     ${PYBIN}/pip install --user numpy
+    ${PYBIN}/pip install --upgrade pip
     ${PYBIN}/pip install itk --user --no-cache-dir --no-index -f /work/dist
     (cd $HOME && ${PYBIN}/python -c 'from itk import ITKCommon;')
     (cd $HOME && ${PYBIN}/python -c 'import itk; image = itk.Image[itk.UC, 2].New()')


### PR DESCRIPTION
We need to upgracde almalinux-release to get new GPG keys so we can install the sudo and ninja-build packages.

We need to update the cmake version for better Python Stable ABI support to build the 3.11 wheels.

We need to upgrade pip in the image so it knows how to install the Stable ABI wheels.

We no-longer remove the old wheels after running auditwheel because they start with the same name.