### PR TITLE
BUG: Fix CMake options scikit-build-core on macOS and Linux

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -146,7 +146,7 @@ for PYBIN in "${PYBINARIES[@]}"; do
         --config-setting=cmake.define.BUILD_TESTING:BOOL=OFF \
         --config-setting=cmake.define.Python3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
         --config-setting=cmake.define.Python3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
-        ${CMAKE_OPTIONS} \
+        ${CMAKE_OPTIONS//'-D'/'--config-setting=cmake.define.'} \
       || exit 1
     fi
 done

--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -149,7 +149,7 @@ for VENV in "${VENVS[@]}"; do
         --config-setting=cmake.define.BUILD_TESTING:BOOL=OFF \
         --config-setting=cmake.define.Python3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE} \
         --config-setting=cmake.define.Python3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR} \
-        ${CMAKE_OPTIONS} \
+        ${CMAKE_OPTIONS//'-D'/'--config-setting=cmake.define.'} \
       || exit 1
     fi
 done

--- a/scripts/windows-download-cache-and-build-module-wheels.ps1
+++ b/scripts/windows-download-cache-and-build-module-wheels.ps1
@@ -104,7 +104,7 @@ if ("$setup_options".length -gt 0) {
   $build_command = "$build_command $setup_options"
 }
 if("$cmake_options".length -gt 0) {
-  $build_command = "$build_command -- `"$cmake_options`""
+  $build_command = "$build_command -- $cmake_options"
 }
 echo $build_command
 


### PR DESCRIPTION
This is propagating to MacOS and Linux what's in Windows:
https://github.com/InsightSoftwareConsortium/ITKPythonPackage/blob/master/scripts/windows_build_module_wheels.py#L99

The Linux version has been tested in https://github.com/RTKConsortium/ITKCudaCommon/actions/runs/9275896116/job/25521657471. I haven't tested MacOS' version.