### PR TITLE
BUG: Fix compatibility with scikit-build(-core) build directory names

### DIFF
--- a/scripts/dockcross-manylinux-build-module-deps.sh
+++ b/scripts/dockcross-manylinux-build-module-deps.sh
@@ -74,7 +74,7 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
 
   echo "Cleaning up module dependency"
   cp ./${MODULE_NAME}/include/* include/
-  find ${MODULE_NAME}/_skbuild -type f -wholename "**/cmake-build/include/*" -print -exec cp {} include \;
+  find ${MODULE_NAME}/*build/*/include -type f -print -exec cp {} include \;
 
   # Cache build archive
   if [[ `(compgen -G ./ITKPythonBuilds-linux*.tar.zst)` ]]; then

--- a/scripts/dockcross-manylinux-cleanup.sh
+++ b/scripts/dockcross-manylinux-cleanup.sh
@@ -31,7 +31,7 @@ fi
 unlink oneTBB-prefix
 ${rm_prefix} rm -rf ITKPythonPackage/
 ${rm_prefix} rm -rf tools/
-${rm_prefix} rm -rf _skbuild/
+${rm_prefix} rm -rf _skbuild/ build/
 ${rm_prefix} rm -rf ./*.egg-info/
 ${rm_prefix} rm -rf ./ITK-*-manylinux${MANYLINUX_VERSION}_${TARGET_ARCH}/
 ${rm_prefix} rm -rf ./ITKPythonBuilds-linux-manylinux*${MANYLINUX_VERSION}*.tar.zst


### PR DESCRIPTION
scikit-build compiles in the directory "_skbuild/cmake-build"

scikit-build-core compiles in an environment-dependent directory, e.g., in the directory "build/cp38-cp38-manylinux_2_28_x86_64"