### PR TITLE
ENH: Make `brew` work in quite mode to silence warnings

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -39,8 +39,8 @@
 
 # Install dependencies
 brew update
-brew install zstd aria2 gnu-tar doxygen ninja
-brew upgrade cmake
+brew install --quiet zstd aria2 gnu-tar doxygen ninja
+brew upgrade --quiet cmake
 
 if [[ $(arch) == "arm64" ]]; then
   tarball_arch="-arm64"


### PR DESCRIPTION
Make `brew` work in quite mode to silence warnings.

Fixes:
```
Warning: Treating doxygen as a formula. For the cask, use homebrew/cask/doxygen or specify the `--cask` flag.
```

and
```
Warning: zstd 1.5.6 is already installed and up-to-date.
To reinstall 1.5.6, run:
  brew reinstall zstd
```

and other similar warnings raised for example in:
https://github.com/InsightSoftwareConsortium/ITKAnalyzeObjectMap/actions/runs/10012233814