### PR TITLE
ENH: Upgrade `rustup` in macOS Python module build script

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -40,7 +40,7 @@
 # Install dependencies
 brew update
 brew install --quiet zstd aria2 gnu-tar doxygen ninja
-brew upgrade --quiet cmake
+brew upgrade --quiet cmake rustup
 
 if [[ $(arch) == "arm64" ]]; then
   tarball_arch="-arm64"


### PR DESCRIPTION
Upgrade `rustup` in macOS Python module build script.

Fixes:
```
rustup is outdated!
To avoid broken installations, as soon as possible please run:
brew upgrade
Or, if you're OK with a less reliable fix: brew upgrade rustup
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKAnalyzeObjectMap/actions/runs/10135042732