### PR TITLE
BUG: Use GNU tar instead of MacOS tar for checkpoint option

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -54,7 +54,7 @@ if [[ ! -f ITKPythonBuilds-macosx${tarball_arch}.tar.zst ]]; then
 fi
 unzstd --long=31 ITKPythonBuilds-macosx${tarball_arch}.tar.zst -o ITKPythonBuilds-macosx${tarball_arch}.tar
 PATH="$(dirname $(brew list gnu-tar | grep gnubin)):$PATH"
-tar xf ITKPythonBuilds-macosx${tarball_arch}.tar --checkpoint=10000 --checkpoint-action=dot
+gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --checkpoint=10000 --checkpoint-action=dot
 rm ITKPythonBuilds-macosx${tarball_arch}.tar
 
 # Optional: Update build scripts


### PR DESCRIPTION
The action started failing with the message:
```
tar: Option --checkpoint=10000 is not supported                                                                                             
```
See [here](https://github.com/RTKConsortium/RTK/actions/runs/10685686663/job/29619116447) for the result before the patch here [after](https://github.com/RTKConsortium/RTK/actions/runs/10689859485/job/29632952408) the patch.
