### PR TITLE
BUG: Remove existing IPP directory before moving

### DIFF
--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -86,6 +86,9 @@ if [[ -n ${ITKPYTHONPACKAGE_TAG} ]]; then
 fi
 
 # Run build scripts
+if [[ -d /Users/svc-dashboard/D/P/ITKPythonPackage ]]; then
+  sudo rm -rf /Users/svc-dashboard/D/P/ITKPythonPackage
+fi
 sudo mkdir -p /Users/svc-dashboard/D/P && sudo chown $UID:$GID /Users/svc-dashboard/D/P && mv ITKPythonPackage /Users/svc-dashboard/D/P/
 
 # Optionally install baseline Python versions


### PR DESCRIPTION
Fixes the following issue when building a module depending on another remote module:
mv: rename ITKPythonPackage to /Users/svc-dashboard/D/P/ITKPythonPackage: Directory not empty