### PR TITLE
BUG: Do not clobber auditwheel manylinux module wheel

### DIFF
--- a/scripts/internal/manylinux-build-module-wheels.sh
+++ b/scripts/internal/manylinux-build-module-wheels.sh
@@ -167,6 +167,6 @@ done
 
 if compgen -G "dist/itk*-linux*.whl" > /dev/null; then
   for itk_wheel in dist/itk*-linux*.whl; do
-    mv ${itk_wheel} ${itk_wheel/linux/manylinux${MANYLINUX_VERSION}}
+    rm ${itk_wheel}
   done
 fi


### PR DESCRIPTION
mv is overwriting the manylinux wheel that auditwheel generated previously. This wheel contains the fixed up shared library that points to libtbb from the itk-core package. Otherwise, this will result in:

  ImportError: libtbb.so.12: cannot open shared object file: No such file or directory

at runtime on systems without that library.