### PR TITLE
Module Intel MacOS wheels compilation

### DIFF
--- a/scripts/macpython-build-module-wheels.sh
+++ b/scripts/macpython-build-module-wheels.sh
@@ -71,6 +71,7 @@ fi
 
 VENV="${VENVS[0]}"
 Python3_EXECUTABLE=${VENV}/bin/python3
+dot_clean ${VENV}
 ${Python3_EXECUTABLE} -m pip install --no-cache delocate
 DELOCATE_LISTDEPS=${VENV}/bin/delocate-listdeps
 DELOCATE_WHEEL=${VENV}/bin/delocate-wheel

--- a/scripts/macpython-build-tarball.sh
+++ b/scripts/macpython-build-tarball.sh
@@ -13,6 +13,7 @@ if test $(arch) == "arm64"; then
 fi
 
 pushd /Users/svc-dashboard/D/P > /dev/null
+dot_clean ITKPythonPackage
 tar -cf ITKPythonBuilds-macosx${arch_postfix}.tar \
   ITKPythonPackage/ITK-* \
   ${tbb_contents} \

--- a/scripts/macpython-download-cache-and-build-module-wheels.sh
+++ b/scripts/macpython-download-cache-and-build-module-wheels.sh
@@ -55,7 +55,7 @@ if [[ ! -f ITKPythonBuilds-macosx${tarball_arch}.tar.zst ]]; then
 fi
 unzstd --long=31 ITKPythonBuilds-macosx${tarball_arch}.tar.zst -o ITKPythonBuilds-macosx${tarball_arch}.tar
 PATH="$(dirname $(brew list gnu-tar | grep gnubin)):$PATH"
-gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --checkpoint=10000 --checkpoint-action=dot \
+gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --warning=no-unknown-keyword --checkpoint=10000 --checkpoint-action=dot \
   ITKPythonPackage/ITK-source \
   ITKPythonPackageRequiredExtractionDir.txt \
   ITKPythonPackage/scripts
@@ -64,7 +64,7 @@ gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --checkpoint=10000 --checkpoin
 args=( "$@"  )
 source ITKPythonPackage/scripts/macpython-build-common.sh
 for version in "$PYTHON_VERSIONS"; do
-  gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --checkpoint=10000 --checkpoint-action=dot \
+  gtar xf ITKPythonBuilds-macosx${tarball_arch}.tar --warning=no-unknown-keyword --checkpoint=10000 --checkpoint-action=dot \
     --wildcards "ITKPythonPackage/ITK-${version}-macosx*" \
     "ITKPythonPackage/venvs/${version}"
 done


### PR DESCRIPTION
ITK v5.4.3 has Intel MacOS wheels but the generation of module Intel MacOS wheels has been disabled per https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/commit/28c417088f004666921794227b08a75b0a8c19d4. This PR adresses the issue which was tracked down by
(1) adding the -v option to  `${Python3_EXECUTABLE} -m pip install --no-cache delocate` which indicated a problem in reading `ITKPythonPackage/venvs/3.11/lib/python3.11/site-packages/._distutils-precedence.pth`.
(2) calling `dot_clean` to remove all the MacOS specific `._*` files.
This has been tested in https://github.com/RTKConsortium/RTK/actions/runs/15493226615.

I know there won't be more Intel MacOS ITK wheels in the future but  in my opinion it's still worth building module wheels against ITK v5.4.3 until new versions are released.