### PR TITLE
ENH: Copy .in and .init files of modules for use in other modules

### DIFF
--- a/scripts/dockcross-manylinux-build-module-deps.sh
+++ b/scripts/dockcross-manylinux-build-module-deps.sh
@@ -74,6 +74,8 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
 
   echo "Cleaning up module dependency"
   cp ./${MODULE_NAME}/include/* include/
+  find ${MODULE_NAME}/wrapping -name '*.in' -print -exec cp {} wrapping \;
+  find ${MODULE_NAME}/wrapping -name '*.init' -print -exec cp {} wrapping \;
   find ${MODULE_NAME}/*build/*/include -type f -print -exec cp {} include \;
 
   # Cache build archive

--- a/scripts/macpython-build-module-deps.sh
+++ b/scripts/macpython-build-module-deps.sh
@@ -59,6 +59,7 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
   cp ./${MODULE_NAME}/include/* include/
   find ${MODULE_NAME}/wrapping -name '*.in' -print -exec cp {} wrapping \;
   find ${MODULE_NAME}/wrapping -name '*.init' -print -exec cp {} wrapping \;
+  find ${MODULE_NAME}/*build/*/include -type f -print -exec cp {} include \;
   rm -f ./${MODULE_NAME}/ITKPythonBuilds-macosx.tar.zst
 done
 

--- a/scripts/macpython-build-module-deps.sh
+++ b/scripts/macpython-build-module-deps.sh
@@ -57,6 +57,8 @@ for MODULE_INFO in ${ITK_MODULE_PREQ_TOPLEVEL//:/ }; do
   popd
 
   cp ./${MODULE_NAME}/include/* include/
+  find ${MODULE_NAME}/wrapping -name '*.in' -print -exec cp {} wrapping \;
+  find ${MODULE_NAME}/wrapping -name '*.init' -print -exec cp {} wrapping \;
   rm -f ./${MODULE_NAME}/ITKPythonBuilds-macosx.tar.zst
 done
 


### PR DESCRIPTION
If a module has .in and .init wrapping files for generating code for a list of image types, they might be used in other modules. This happens in RTK using CudaCommon with CudaImage.i.in.

This patch has been tested in RTKConsortium/RTK#813 to test RTKConsortium/ITKCudaCommon#43.

cc @LucasGandel 