### PR TITLE
COMP: Bootstrap pip via ensurepip on Windows wheel build to fix Python 3.10+

### DIFF
--- a/scripts/windows_build_module_wheels.py
+++ b/scripts/windows_build_module_wheels.py
@@ -52,6 +52,22 @@ def build_wheels(py_envs=DEFAULT_PY_ENVS, cleanup=True, cmake_options=[]):
 
         with push_env(PATH="%s%s%s" % (path, os.pathsep, os.environ["PATH"])):
             # Install dependencies
+            #
+            # Bootstrap pip from CPython's bundled ensurepip wheel BEFORE
+            # invoking the system pip, to sidestep a chicken-and-egg failure
+            # on Python 3.10+ runners.  scikit-ci-addons' install-python.ps1
+            # downloads get-pip.py from a pinned GitHub gist (jcfr commit
+            # 8478d43e), which installs a pip old enough to vendor an
+            # html5lib that still does `from collections import Mapping`
+            # (removed in Python 3.10).  Loading that pip to upgrade itself
+            # raises ImportError before any package operation can run.
+            # CPython's ensurepip module installs the pip wheel that ships
+            # with the interpreter (>= 21.x for Python 3.10), which has a
+            # working html5lib >= 1.1; the subsequent `pip install pip
+            # --upgrade` then succeeds normally.
+            check_call(
+                [python_executable, "-m", "ensurepip", "--upgrade", "--default-pip"]
+            )
             check_call([python_executable, "-m", "pip", "install", "pip", "--upgrade"])
             requirements_file = os.path.join(ROOT_DIR, "requirements-dev.txt")
             if os.path.exists(requirements_file):


### PR DESCRIPTION
Bootstrap pip via `python -m ensurepip --upgrade --default-pip` before invoking the system pip in `windows_build_module_wheels.py`. Sidesteps a Python 3.10+ chicken-and-egg failure where the system pip's vendored `html5lib` does `from collections import Mapping` (removed in 3.10) and dies before any `pip install` can run.

Surfaced by [KitwareMedical/ITKUltrasound#246](https://github.com/KitwareMedical/ITKUltrasound/pull/246).

<details>
<summary>Failure trace</summary>

```
File ".../Temp/tmpXXXX/pip.zip/pip/_vendor/html5lib/_trie/_base.py", line 3
ImportError: cannot import name 'Mapping' from 'collections' (C:\Python310-x64\lib\collections\__init__.py)
```

Consistent on Python 3.10 and 3.11 across all `build-windows-python-packages` matrix jobs.

</details>

<details>
<summary>Root cause</summary>

`scripts/windows-download-cache-and-build-module-wheels.ps1` IEXes the upstream `install-python.ps1` from `scikit-build/scikit-ci-addons`. That script's line 160 downloads `get-pip.py` from a **pinned GitHub gist** (`jcfr/db7347e8708b9f32d45ab36125fad6d3@8478d43e`) rather than `https://bootstrap.pypa.io/get-pip.py`. The pinned gist installs a pip old enough to vendor an html5lib that still uses `from collections import Mapping`.

When `windows_build_module_wheels.py:55` runs `python -m pip install pip --upgrade`, the system pip loads its `_vendor/html5lib._trie._base` and dies before any package-resolution logic runs. The bug cannot be worked around using the broken pip itself.

</details>

<details>
<summary>Why ensurepip works</summary>

`ensurepip` installs the pip wheel that CPython itself bundled at release time (`Lib/ensurepip/_bundled/`), which is ≥ 21.x for Python 3.10 and ≥ 23.x for 3.11 — both ship a working `html5lib` ≥ 1.1 with the `collections.abc.Mapping` migration applied. Once ensurepip writes a fresh pip into the system Python, the subsequent `pip install pip --upgrade` finds a working pip and proceeds normally.

</details>

<details>
<summary>What is NOT changed</summary>

- **`windows-download-cache-and-build-module-wheels.ps1`**: still IEXes the upstream `install-python.ps1` unchanged. The fix is purely Python-side; no scikit-ci-addons interaction needed.
- **`scripts/windows_build_wheels.py`**: unchanged. Its pip operations go through a virtualenv created by `virtualenv.exe`, and modern virtualenv ≥ 20.x ships its own bundled pip seed wheels instead of copying the (broken) system pip into the new venv.
- **The upstream `scikit-ci-addons` pinned gist URL**: ideally fixed at the source eventually (replace with `bootstrap.pypa.io/get-pip.py`), but that's a separate, broader-scope change in a different repo.

</details>

## Test plan
- [ ] Windows wheel build (Python 3.10) on this repo's CI passes the bootstrap step
- [ ] Windows wheel build (Python 3.11) on this repo's CI passes the bootstrap step
- [ ] After merge, KitwareMedical/ITKUltrasound#246's `build-windows-python-packages (10)` and `(11)` jobs progress past `pip install` into actual C++ compilation

<!--
provenance: claude-code session 2026-04-11
discovery_pr: KitwareMedical/ITKUltrasound#246
modified_files:
  - scripts/windows_build_module_wheels.py (build_wheels function, lines 53-71 region after edit)
upstream_root_cause:
  repo: scikit-build/scikit-ci-addons
  file: windows/install-python.ps1
  line: 160
  issue: get-pip.py pinned to old gist (jcfr/db7347e8708b9f32d45ab36125fad6d3@8478d43e)
  ideal_fix: replace with https://bootstrap.pypa.io/get-pip.py
related_prs:
  - KitwareMedical/ITKUltrasound#246 (consumer, marked WIP pending this merge)
-->